### PR TITLE
Auto refresh on Fugitive or Worktree changes

### DIFF
--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1441,8 +1441,10 @@ function! s:Rebase(remote, autostash, interactive) abort
 	let gitcmd = "rebase "
   endif
 
+  let l:dispatch_opts = {}
   if a:interactive
 	  let gitcmd = l:gitcmd . "-i "
+	  let l:dispatch_opts["no_dispatch"] = 1
   endif
 
   if a:remote
@@ -1450,14 +1452,14 @@ function! s:Rebase(remote, autostash, interactive) abort
       let v:warningmsg = 'No tracking branch for ' . branch.name
       return 1
     else
-      call s:git_cmd(gitcmd . ' ' . branch.tracking, 1)
+      call s:git_cmd(gitcmd . ' ' . branch.tracking, 1, l:dispatch_opts)
     endif
   else
     if branch.fullname ==# s:get_current_branch()
       let v:warningmsg = 'Can''t rebase off of self'
       return 1
     else
-      call s:git_cmd(gitcmd . ' ' . branch.fullname, 1)
+      call s:git_cmd(gitcmd . ' ' . branch.fullname, 1, l:dispatch_opts)
     endif
   endif
 

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -978,7 +978,7 @@ function! s:Render() abort
     autocmd CursorMoved twiggy://* call s:show_branch_details()
     autocmd CursorMoved twiggy://* call s:update_last_branch_under_cursor()
     autocmd BufReadPost,BufEnter twiggy://* call <SID>Refresh()
-    autocmd BufReadPost,BufEnter fugitive://* call <SID>Refresh()
+    " autocmd BufReadPost,BufEnter fugitive://* call <SID>Refresh()
 	" autocmd User FugitiveChanged call <SID>Refresh() 
 	autocmd User WorktreeCheckout call <SID>Refresh() 
   augroup END

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1580,20 +1580,11 @@ function! s:Rename() abort
   let branch = s:branch_under_cursor()
   let new_name = input("Rename " . branch.fullname . " to: ", branch.fullname)
   redraw
-<<<<<<< HEAD
   if !empty(new_name)
 	  echo "Renaming \"" . branch.fullname . "\" to \"" . new_name . "\"... "
 	  call s:git_cmd("branch -m " . branch.fullname . " " . new_name, 0)
 	  call fugitive#ReloadStatus()
   endif
-||||||| parent of c14638c (feat: reload fugitive status after ops)
-  echo "Renaming \"" . branch.fullname . "\" to \"" . new_name . "\"... "
-  call s:git_cmd("branch -m " . branch.fullname . " " . new_name, 0)
-=======
-  echo "Renaming \"" . branch.fullname . "\" to \"" . new_name . "\"... "
-  call s:git_cmd("branch -m " . branch.fullname . " " . new_name, 0)
-  call fugitive#ReloadStatus()
->>>>>>> c14638c (feat: reload fugitive status after ops)
 endfunction
 
 "     {{{3 Stash

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -977,7 +977,8 @@ function! s:Render() abort
     autocmd!
     autocmd CursorMoved twiggy://* call s:show_branch_details()
     autocmd CursorMoved twiggy://* call s:update_last_branch_under_cursor()
-    autocmd BufReadPost,BufEnter,VimResized twiggy://* call <SID>Refresh()
+    autocmd BufReadPost,BufEnter twiggy://* call <SID>Refresh()
+    autocmd BufReadPost,BufEnter fugitive://* call <SID>Refresh()
 	" autocmd User FugitiveChanged call <SID>Refresh() 
   augroup END
 

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -977,9 +977,12 @@ function! s:Render() abort
     autocmd!
     autocmd CursorMoved twiggy://* call s:show_branch_details()
     autocmd CursorMoved twiggy://* call s:update_last_branch_under_cursor()
-    autocmd BufReadPost,BufEnter twiggy://* call <SID>Refresh()
-    " autocmd BufReadPost,BufEnter fugitive://* call <SID>Refresh()
-	" autocmd User FugitiveChanged call <SID>Refresh() 
+	" autocmd User FugitiveChanged let t:branches_changed = 1
+	" autocmd CmdlineLeave * if exists("t:branches_changed") && t:branches_changed | let t:branches_changed = 0 | call <SID>Refresh() | endif
+	
+    autocmd CmdlineLeave * if histget(":", -1) =~ '\v^G(it)?\s+(fetch|pull|push|switch|checkout|branch)' | call <SID>Refresh() |let t:branches_changed = 1 | endif
+	autocmd User FugitiveChanged if exists("t:branches_changed") && t:branches_changed | let t:branches_changed = 0 | call <SID>Refresh() | endif
+
 	autocmd User WorktreeCheckout call <SID>Refresh() 
   augroup END
 
@@ -1168,28 +1171,37 @@ function! s:Refresh() abort
   endif
 
   let t:refreshing = 1
-  let t:switch_buff = 0
+
   if &filetype !=# 'twiggy'
-
-	" Store old buffer and cursor position in that buffer
-    let t:old_bufnr = bufnr('')
-	let t:line = line('.')
-	let t:col = col('.')
-	let t:switch_buff = 1
-
-	if exists('b:git_dir')
-		let t:twiggy_git_dir = b:git_dir
-	endif
+    if exists('b:git_dir')
+      let t:twiggy_git_dir = b:git_dir
+    endif
     let t:twiggy_git_cmd = FugitiveShellCommand()
-    call s:buffocus(t:twiggy_bufnr)
   endif
 
-  call s:Render()
+  let twiggy_winid = bufwinid(t:twiggy_bufnr)
 
-  if t:switch_buff
-	" Switch back to old cursor position in the previous buffer
-	call s:buffocus(t:old_bufnr)
-	call cursor(t:line, t:col)
+  if &filetype !=# 'twiggy' && exists('*win_execute') && twiggy_winid != -1
+    call win_execute(twiggy_winid, 'call s:Render()')
+  else
+    let t:switch_buff = 0
+    if &filetype !=# 'twiggy'
+      " Store old buffer and cursor position in that buffer
+      let t:old_bufnr = bufnr('')
+      let t:line = line('.')
+      let t:col = col('.')
+      let t:switch_buff = 1
+
+      call s:buffocus(t:twiggy_bufnr)
+    endif
+
+    call s:Render()
+
+    if t:switch_buff
+      " Switch back to old cursor position in the previous buffer
+      call s:buffocus(t:old_bufnr)
+      call cursor(t:line, t:col)
+    endif
   endif
 
   unlet t:refreshing

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1308,6 +1308,8 @@ function! s:Checkout(track) abort
 
   doautocmd User TwiggyCheckout
 
+  call fugitive#ReloadStatus()
+
   return 0
 endfunction
 
@@ -1331,6 +1333,8 @@ function! s:CheckoutAs() abort
     let s:last_branch_under_cursor = 0
 
     doautocmd User TwiggyCheckout
+
+	call fugitive#ReloadStatus()
 
     return 0
   endif
@@ -1455,6 +1459,9 @@ function! s:Continue(type) abort
   else
     call s:git_cmd(a:type . ' --continue', 1, {"no_dispatch": 1})
   endif
+
+  redraw
+  call fugitive#ReloadStatus()
 endfunction
 
 "     {{{3 Skip Rebase
@@ -1474,6 +1481,7 @@ function! s:Abort(type) abort
   endif
   cclose
   redraw | echo a:type . ' aborted'
+  call fugitive#ReloadStatus()
 endfunction
 
 "     {{{3 Stash Continue
@@ -1560,11 +1568,20 @@ function! s:Rename() abort
   let branch = s:branch_under_cursor()
   let new_name = input("Rename " . branch.fullname . " to: ", branch.fullname)
   redraw
+<<<<<<< HEAD
   if !empty(new_name)
 	  echo "Renaming \"" . branch.fullname . "\" to \"" . new_name . "\"... "
 	  call s:git_cmd("branch -m " . branch.fullname . " " . new_name, 0)
 	  call fugitive#ReloadStatus()
   endif
+||||||| parent of c14638c (feat: reload fugitive status after ops)
+  echo "Renaming \"" . branch.fullname . "\" to \"" . new_name . "\"... "
+  call s:git_cmd("branch -m " . branch.fullname . " " . new_name, 0)
+=======
+  echo "Renaming \"" . branch.fullname . "\" to \"" . new_name . "\"... "
+  call s:git_cmd("branch -m " . branch.fullname . " " . new_name, 0)
+  call fugitive#ReloadStatus()
+>>>>>>> c14638c (feat: reload fugitive status after ops)
 endfunction
 
 "     {{{3 Stash

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1161,7 +1161,7 @@ endfunction
 
 "     {{{3 Refresh
 function! s:Refresh() abort
-  if exists('t:refreshing') || !exists('t:twiggy_bufnr') || !exists('b:git_dir')
+  if exists('t:refreshing') || !exists('t:twiggy_bufnr') || (!exists('t:twiggy_git_dir') && !exists('b:git_dir'))
     return
   endif
 
@@ -1175,7 +1175,9 @@ function! s:Refresh() abort
 	let t:col = col('.')
 	let t:switch_buff = 1
 
-    let t:twiggy_git_dir = b:git_dir
+	if exists('b:git_dir')
+		let t:twiggy_git_dir = b:git_dir
+	endif
     let t:twiggy_git_cmd = FugitiveShellCommand()
     call s:buffocus(t:twiggy_bufnr)
   endif

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -991,13 +991,13 @@ function! s:Render() abort
   nnoremap <buffer> <silent> cs<space> :<C-U>G switch<space>
   nnoremap <buffer> <silent> cr<space> :<C-U>G rebase<space>
 
-  nnoremap <buffer> <silent> j      :<C-U>call <SID>traverse_branches('j')<CR>
-  nnoremap <buffer> <silent> k      :<C-U>call <SID>traverse_branches('k')<CR>
-  nnoremap <buffer> <silent> <Down> :<C-U>call <SID>traverse_branches('j')<CR>
-  nnoremap <buffer> <silent> <Up>   :<C-U>call <SID>traverse_branches('k')<CR>
-  nnoremap <buffer> <silent> <C-N>  :<C-U>call <SID>traverse_groups('j')<CR>
-  nnoremap <buffer> <silent> <C-P>  :<C-U>call <SID>traverse_groups('k')<CR>
-  nnoremap <buffer> <silent> J      :<C-U>call <SID>jump_to_current_branch()<CR>
+  nnoremap <buffer> <silent> j		<cmd>call <SID>traverse_branches('j')<CR>
+  nnoremap <buffer> <silent> k      <cmd>call <SID>traverse_branches('k')<CR>
+  nnoremap <buffer> <silent> <Down> <cmd>call <SID>traverse_branches('j')<CR>
+  nnoremap <buffer> <silent> <Up>   <cmd>call <SID>traverse_branches('k')<CR>
+  nnoremap <buffer> <silent> <C-N>  <cmd>call <SID>traverse_groups('j')<CR>
+  nnoremap <buffer> <silent> <C-P>  <cmd>call <SID>traverse_groups('k')<CR>
+  nnoremap <buffer> <silent> J      <cmd>call <SID>jump_to_current_branch()<CR>
   if s:showing_full_ui()
     nnoremap <buffer> <silent> gg    :normal! 4gg<CR>
   else

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -980,6 +980,7 @@ function! s:Render() abort
     autocmd BufReadPost,BufEnter twiggy://* call <SID>Refresh()
     autocmd BufReadPost,BufEnter fugitive://* call <SID>Refresh()
 	" autocmd User FugitiveChanged call <SID>Refresh() 
+	autocmd User WorktreeCheckout call <SID>Refresh() 
   augroup END
 
   nnoremap <buffer> <silent> cf<space> :<C-U>G fetch<space>


### PR DESCRIPTION
This pull request improves the synchronization between Twiggy and Fugitive by ensuring that Fugitive's status is refreshed after key branch operations, and enhances the reliability of buffer refresh logic. It also updates key mappings for consistency and addresses edge cases in branch renaming.

**Integration with Fugitive and Refresh Logic:**
- Ensures Fugitive's status is reloaded after branch checkouts, renames, continues, and aborts, keeping the status line and other Fugitive features in sync with Twiggy operations. [[1]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59R1323-R1324) [[2]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59R1349-R1350) [[3]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59R1474-R1476) [[4]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59R1496) [[5]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59R1583-R1596)
- Refines the logic in `s:Refresh()` to better handle cases when the Twiggy buffer or git directory may not exist, and to properly focus and restore buffers and cursor positions. [[1]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59L1164-L1179) [[2]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59R1205)

**Autocommand and Event Handling:**
- Updates autocommands to more reliably trigger a refresh after relevant git commands (fetch, pull, push, switch, checkout, branch) and on specific user events, improving the accuracy of the branch list display.

**Key Mapping Consistency:**
- Changes normal mode mappings from using `:<C-U>` to `<cmd>`, aligning with modern Vim best practices and improving readability.