### PR TITLE
Don't use `:Dispatch` when Vim TUI needed

### DIFF
--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -111,13 +111,19 @@ endfunction
 
 " {{{1 System
 "   {{{2 cmd
-function! s:system(cmd, bg) abort
+function! s:system(cmd, bg, dispatch_opts={}) abort
   let command = a:cmd
 
   if a:bg
     if exists('g:loaded_dispatch') && g:loaded_dispatch &&
-          \ g:twiggy_use_dispatch
-      exec ':Dispatch ' . command
+          \ g:twiggy_use_dispatch 
+		if has_key(a:dispatch_opts, "no_dispatch") && a:dispatch_opts.no_dispatch
+			exec ":!" . command
+		elseif has_key(a:dispatch_opts, "use_start") && a:dispatch_opts.use_start
+		  exec ':Start ' . command
+		else
+		  exec ':Dispatch ' . command
+		endif
     else
       exec ':!' . command
     endif
@@ -151,13 +157,13 @@ function! s:gitize(cmd) abort
 endfunction
 
 "   {{{2 git_cmd
-function! s:git_cmd(cmd, bg) abort
+function! s:git_cmd(cmd, bg, dispatch_opts={}) abort
   let cmd = s:gitize(a:cmd)
   let s:git_cmd_run = 1
   if a:bg
-    call s:system(cmd, a:bg)
+    call s:system(cmd, a:bg, a:dispatch_opts)
   else
-    return s:system(cmd, a:bg)
+    return s:system(cmd, a:bg, a:dispatch_opts)
   endif
 endfunction
 
@@ -466,7 +472,7 @@ function! s:get_uniq_branch_names_from_reflog() abort
   let cmd.= "<(" . s:gitize('reflog') . " | awk -F\" \" '/checkout: moving from/ { print $8 }' | "
   let cmd.= "awk " . shellescape('!f[$0]++') . ")"
 
-  return s:system(cmd, 0)
+  return s:system(cmd, 0, 0)
 endfunction
 
 "   {{{2 get_merged_branches
@@ -481,7 +487,7 @@ function! s:get_by_commiter_date(type) abort
         \ "for-each-ref --sort=-committerdate --format='%(refname)' " .
         \ "refs/" . a:type . " | sed 's/refs\\/" .
         \ s:sub(a:type, '/', '\\/') . "\\///g'")
-  return s:system(cmd, 0)
+  return s:system(cmd, 0, 0)
 endfunction
 
 "   {{{2 update_last_branch_under_cursor
@@ -1443,13 +1449,16 @@ function! s:Continue(type) abort
   if a:type ==? 'stash'
       call s:ContinueStash()
   else
-    call s:git_cmd(a:type . ' --continue', 1)
+    call s:git_cmd(a:type . ' --continue', 1, {"no_dispatch": 1})
   endif
 endfunction
 
 "     {{{3 Skip Rebase
 function! s:Skip() abort
-  call s:git_cmd('rebase --skip', 1)
+  call s:git_cmd('rebase --skip', 1, {"no_dispatch": 1})
+
+  redraw
+  call fugitive#ReloadStatus()
 endfunction
 
 "     {{{3 Merge/Rebase/Cherry-Pick/Stash Abort
@@ -1465,7 +1474,7 @@ endfunction
 
 "     {{{3 Stash Continue
 function! s:ContinueStash() abort
-  call s:git_cmd('commit', 1)
+  call s:git_cmd('commit', 1, {"no_dispatch": 1})
 endfunction
 
 "     {{{3 Stash Abort


### PR DESCRIPTION
This pull request updates the way system and git commands are executed in the `autoload/twiggy.vim` file, adding more flexibility for background execution and integration with external tools like `vim-dispatch`. The main focus is on allowing options to control whether commands are run through `Dispatch`, `Start`, or directly, and ensuring certain git operations bypass dispatch when necessary.

**Command execution improvements:**

* The `s:system` and `s:git_cmd` functions now accept an optional `dispatch_opts` dictionary to control how commands are run (e.g., directly, via `Dispatch`, or via `Start`). This allows finer control over command execution, especially when using background tasks or integrating with plugins like `vim-dispatch`. [[1]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59L114-R126) [[2]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59L154-R166)
* Calls to `s:system` throughout the codebase have been updated to pass the new `dispatch_opts` argument, ensuring compatibility and consistent behavior. [[1]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59L469-R475) [[2]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59L484-R490)

**Behavioral changes for git operations:**

* The `s:Continue`, `s:Skip`, and `s:ContinueStash` functions now explicitly set `{"no_dispatch": 1}` when calling `s:git_cmd`, ensuring these critical git operations bypass `vim-dispatch` and run directly. This prevents issues with background execution for commands that require immediate user interaction or output. [[1]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59L1446-R1463) [[2]](diffhunk://#diff-309d264f23daaa49847c2d8d607a840c4c64a68d493d1b8109e12a1bf8aaca59L1468-R1479)
* The `s:Skip` function now also redraws the screen and reloads the Fugitive status after skipping a rebase, improving user feedback and state accuracy.
