### PR TITLE
bugfix: highlight current branch with slash sorting

### DIFF
--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -447,6 +447,13 @@ function! s:get_current_branch() abort
   return s:git_cmd('rev-parse --abbrev-ref HEAD', 0)[0]
 endfunction
 
+"   {{{2 get_current_branch_remote
+function! s:get_current_branch_remote() abort
+  let remote = s:git_cmd('rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null', 0)
+  if empty(remote) | return "" | endif
+  return remote[0]
+endfunction
+
 "   {{{2 branch_exists
 function! s:branch_exists(branch) abort
   call s:git_cmd('show-ref --verify --quiet refs/heads/' . a:branch, 0)
@@ -1121,7 +1128,7 @@ function! s:Render() abort
   " ────────────────────────────────────────────────────────────────────────
   " Conceal slash prefix
   " ────────────────────────────────────────────────────────────────────────
-  function! ConcealSlashBranches(current, conceal_local, conceal_remote)
+  function! ConcealSlashBranches(current, current_remote, conceal_local, conceal_remote)
     syntax clear TwiggySlash
     syntax clear TwiggySlashPrefix
     syntax clear TwiggySlashCurrent
@@ -1141,17 +1148,27 @@ function! s:Render() abort
 
 	syntax match TwiggySlashBranchName   /\v[-_[:alnum:].\/]+/ contained
 	syntax match TwiggySlashBranchPrefix /\v[-_[:alnum:].]+\// contained conceal
-
-    let parts = split(a:current, '/')
-    if len(parts) < 2
-      return
-    endif
   
-    let prefix = parts[0] .. '/'
-    let name = join(parts[1 :], '/')
+	if a:conceal_local && !empty(a:current)
+		let parts = split(a:current, '/')
+		if len(parts) < 2 | return | endif
 
-	if a:conceal_local
+		let prefix = parts[0] .. '/'
+		let name = join(parts[1 :], '/')
+
 		execute('syntax match TwiggySlashCurrent /\v' .. escape(slash_prefix, '()') .. escape(a:current, '\/\') .. '/ contains=TwiggySlashPrefix,TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
+		execute('syntax match TwiggySlashCurrentPrefix /\V' .. escape(prefix, '\/\') .. '/ contained conceal nextgroup=TwiggySlashCurrentName')
+		execute('syntax match TwiggySlashCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
+	endif
+
+	if a:conceal_remote && !empty(a:current_remote)
+		let parts = split(a:current_remote, '/')
+		if len(parts) < 3 | return | endif
+
+		let prefix = join(parts[0 : 1], '/') .. '/'
+		let name = join(parts[2 :], '/')
+
+		execute('syntax match TwiggySlashCurrent /\v' .. escape(slash_prefix, '()') .. escape(a:current_remote, '\/\') .. '/ contains=TwiggySlashPrefix,TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
 		execute('syntax match TwiggySlashCurrentPrefix /\V' .. escape(prefix, '\/\') .. '/ contained conceal nextgroup=TwiggySlashCurrentName')
 		execute('syntax match TwiggySlashCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
 	endif
@@ -1163,12 +1180,15 @@ function! s:Render() abort
     let &l:concealcursor = 'nvic'
   endfunction
 
+  " TODO: this will highlight remote branches of the same name, even if they
+  " are not tracked by the current branch!
   let current_branch = s:get_current_branch()
+  let current_branch_remote = s:get_current_branch_remote()
   exec "syntax match TwiggyCurrent '\\v%3v" . current_branch . "$'"
   highlight default link TwiggyCurrent Identifier
 
   if g:twiggy_group_locals_by_slash || g:twiggy_group_remotes_by_slash
-	  call ConcealSlashBranches(current_branch, g:twiggy_group_locals_by_slash, g:twiggy_group_remotes_by_slash)
+	  call ConcealSlashBranches(current_branch, current_branch_remote, g:twiggy_group_locals_by_slash, g:twiggy_group_remotes_by_slash)
   endif
 
   exec "syntax match TwiggyCurrent '\\V\\%1c" . s:icons.current . "'"

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1175,7 +1175,8 @@ function! s:Render() abort
   call s:mapping('dd',      'Delete',           [])
   call s:mapping('yy',      'Yank',	            [])
   call s:mapping('F',       'Fetch',            [0]) " deprecated
-  call s:mapping('f',       'Fetch',            [0]) call s:mapping('m',       'Merge',            [0, ''])
+  call s:mapping('f',       'Fetch',            [0])
+  call s:mapping('m',       'Merge',            [0, ''])
   call s:mapping('M',       'Merge',            [1, ''])
   call s:mapping('gm',      'Merge',            [0, '--no-ff'])
   call s:mapping('gM',      'Merge',            [1, '--no-ff'])

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1387,9 +1387,9 @@ function! s:Render() abort
     syntax match TwiggyHeader "\v%1lTwiggy"
     highlight default link TwiggyHeader Title
     syntax match TwiggyHelpHint "\v%1lHelp: "
-    highlight default link TwiggyHelpHint Question
+    highlight default link TwiggyHelpHint fugitiveHelpHeader
     syntax match TwiggyHelpHintKey "\v%1l\?"
-    highlight default link TwiggyHelpHintKey Question
+    highlight default link TwiggyHelpHintKey fugitiveHelpHeader
   endif
 
   " }}}

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1210,13 +1210,14 @@ function! s:Render() abort
 			let prefix = parts[0] .. '/'
 			let name = join(parts[1 :], '/')
 
-			execute('syntax match TwiggyBranchCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName')
+			execute('syntax match TwiggyBranchCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '$/ contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName')
 			execute('syntax match TwiggyBranchCurrentPrefix /\V(l)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentName')
 			execute('syntax match TwiggyBranchCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
 		endif
 	elseif !a:conceal_local && !empty(a:current)
-		execute('syntax match TwiggyBranchCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName')
+		execute('syntax match TwiggyBranchCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '$/ contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName')
 		syntax match TwiggyBranchCurrentPrefix /\V(l)/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentName
+		echom a:current
 		execute('syntax match TwiggyBranchCurrentName /\V' .. escape(a:current, '\/\') .. '/ contained')
 	endif
 
@@ -1230,7 +1231,7 @@ function! s:Render() abort
 			let name = join(parts[2 :], '/')
 		endif
 
-		execute('syntax match TwiggyBranchCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '/ contains=TwiggyBranchCurrentRemotePrefix,TwiggyBranchCurrentRemoteName')
+		execute('syntax match TwiggyBranchCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '$/ contains=TwiggyBranchCurrentRemotePrefix,TwiggyBranchCurrentRemoteName')
 		execute('syntax match TwiggyBranchCurrentRemotePrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentRemoteName')
 		execute('syntax match TwiggyBranchCurrentRemoteName /\V' .. escape(name, '\/\') .. '/ contained')
 	elseif !a:conceal_remote && !empty(a:current_remote)
@@ -1238,7 +1239,7 @@ function! s:Render() abort
 		let prefix = parts[0] .. '/'
 		let name = join(parts[1 :], '/')
 
-		execute('syntax match TwiggyBranchCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '/ contains=TwiggyBranchCurrentRemotePrefix,TwiggyBranchCurrentRemoteName')
+		execute('syntax match TwiggyBranchCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '$/ contains=TwiggyBranchCurrentRemotePrefix,TwiggyBranchCurrentRemoteName')
 		execute('syntax match TwiggyBranchCurrentRemotePrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentRemoteName')
 		execute('syntax match TwiggyBranchCurrentRemoteName /\V' .. escape(name, '\/\') .. '/ contained')
 	endif

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -252,6 +252,7 @@ function! s:parse_branch(branch, type) abort
     else
       let branch.group = 'local'
       let branch.name = branch.fullname
+      let branch.display_name = "(l)" . branch.fullname
     endif
   else
     let branch.is_local = 0
@@ -1119,9 +1120,11 @@ function! s:Render() abort
   highlight default link TwiggyGroup Type
   
     hi def link TwiggySlash Comment
+    hi def link TwiggyRemoteSlash Comment
     hi def link TwiggySlashPrefix Comment
     hi def link TwiggySlashCurrentPrefix Comment
     hi def link TwiggySlashCurrentName TwiggyCurrent
+    hi def link TwiggySlashCurrentRemoteName TwiggyCurrent
     highlight default link TwiggySlashCurrent Identifier
 	" highlight link TwiggySlashBranchName Normal
 
@@ -1139,28 +1142,40 @@ function! s:Render() abort
 
   function! ConcealSlashBranches(current, current_remote, conceal_local, conceal_remote)
     syntax clear TwiggySlash
+    syntax clear TwiggyRemoteSlash
     syntax clear TwiggySlashPrefix
     syntax clear TwiggySlashCurrent
     syntax clear TwiggySlashCurrentPrefix
     syntax clear TwiggySlashCurrentName
 
-	let slash_prefix = ''
-	if a:conceal_local && a:conceal_remote
-		let slash_prefix = '([lr])'
-	elseif a:conceal_local
-		let slash_prefix = '(l)'
-	elseif a:conceal_remote
-		let slash_prefix = '(r)'
-	endif
+	" let slash_prefix = ''
+	" if a:conceal_local && a:conceal_remote
+	" 	let slash_prefix = '([lr])'
+	" 	let slash_prefix_very_nomagic = '(l\|r)'
+	" elseif a:conceal_local
+	" 	let slash_prefix = '(l)'
+	" 	let slash_prefix_very_nomagic = slash_prefix
+	" elseif a:conceal_remote
+	" 	let slash_prefix = '(r)'
+	" 	let slash_prefix_very_nomagic = slash_prefix
+	" endif
 
-	execute('syntax region TwiggySlash start=/\v' . escape(slash_prefix, '()') . '[-_[:alnum:].]+\// end=/\v[()-_[:alnum:].\/]+/ contains=TwiggySlashBranchPrefix,TwiggySlashBranchName oneline')
+	" execute('syntax region TwiggySlash start=/\v' . escape(slash_prefix, '()') . '[-_[:alnum:].]+\// end=/\v[()-_[:alnum:].\/]+/ contains=TwiggySlashBranchPrefix,TwiggySlashBranchName oneline')
+	" execute('syntax region TwiggySlash start=/\V' . slash_prefix_very_nomagic . '/ end=/\v\S+/ contains=TwiggySlashBranchPrefix,TwiggySlashBranchName,TwiggySlashRemoteBranchPrefix,TwiggySlashRemoteBranchName oneline')
+	" syntax region TwiggySlash start=/\v\([lr]\)/ end=/\v\S+/ contains=TwiggySlashBranchPrefix,TwiggySlashBranchName,TwiggySlashRemoteBranchPrefix,TwiggySlashRemoteBranchName oneline
+	syntax region TwiggySlash start=/\v\(l\)/ end=/\v\S+/ contains=TwiggySlashBranchPrefix,TwiggySlashBranchName oneline
+	syntax region TwiggyRemoteSlash start=/\v\(r\)/ end=/\v\S+/ contains=TwiggySlashRemoteBranchPrefix,TwiggySlashRemoteBranchName oneline
 
-	" local
+	" local: match either (l)prefix/name or (l)
 	syntax match TwiggySlashBranchPrefix /\v\(l\)[-_[:alnum:].]+\// contained conceal nextgroup=TwiggySlashBranchName contains=TwiggySlashPrefix
-	" remote
-	syntax match TwiggySlashBranchPrefix /\v\(r\)[-_[:alnum:].]+\/[-_[:alnum:].]+\// contained conceal nextgroup=TwiggySlashBranchName contains=TwiggySlashPrefix
+	syntax match TwiggySlashBranchPrefix /\v\(l\)/ contained conceal nextgroup=TwiggySlashBranchName contains=TwiggySlashPrefix
 	syntax match TwiggySlashBranchName   /\v[-_[:alnum:].\/]+/ contained
-  
+
+	" remote: match either (r)remote/prefix/name or (r)
+	syntax match TwiggySlashRemoteBranchPrefix /\v\(r\)/ contained conceal nextgroup=TwiggySlashRemoteBranchName contains=TwiggySlashPrefix
+	syntax match TwiggySlashRemoteBranchPrefix /\v\(r\)[-_[:alnum:].]+\/[-_[:alnum:].]+\// contained conceal nextgroup=TwiggySlashRemoteBranchName contains=TwiggySlashPrefix
+	syntax match TwiggySlashRemoteBranchName   /\v[-_[:alnum:].\/]+/ contained
+ 
 	if a:conceal_local && !empty(a:current)
 		let parts = split(a:current, '/')
 		if len(parts) < 2 | return | endif
@@ -1168,6 +1183,7 @@ function! s:Render() abort
 		let prefix = parts[0] .. '/'
 		let name = join(parts[1 :], '/')
 
+	    " TODO exec "syntax match TwiggySlashCurrent '\\v%6v" . a:conceal_local . "$'"
 		execute('syntax match TwiggySlashCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
 		execute('syntax match TwiggySlashCurrentPrefix /\V(l)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName')
 		execute('syntax match TwiggySlashCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
@@ -1180,14 +1196,14 @@ function! s:Render() abort
 		let prefix = join(parts[0 : 1], '/') .. '/'
 		let name = join(parts[2 :], '/')
 
-		" TODO: name clashing with local conceals above!
-		execute('syntax match TwiggySlashCurrent /\v\(r\)' .. escape(a:current_remote, '\/\') .. '/ contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
-		execute('syntax match TwiggySlashCurrentPrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName')
-		execute('syntax match TwiggySlashCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
+		execute('syntax match TwiggySlashCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '/ contains=TwiggySlashCurrentRemotePrefix,TwiggySlashCurrentRemoteName')
+		execute('syntax match TwiggySlashCurrentRemotePrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentRemoteName')
+		execute('syntax match TwiggySlashCurrentRemoteName /\V' .. escape(name, '\/\') .. '/ contained')
 	endif
 
-	echom 'syntax match TwiggySlashPrefix /\v' . escape(slash_prefix, '()') . '/ contained conceal'
-	execute('syntax match TwiggySlashPrefix /\v' . escape(slash_prefix, '()') . '/ contained conceal')
+	" execute('syntax match TwiggySlashPrefix /\v' . escape(slash_prefix, '()') . '/ contained conceal')
+	syntax match TwiggySlashPrefix /\v\(l\)/ contained conceal
+	syntax match TwiggySlashPrefix /\v\(r\)/ contained conceal
   
   endfunction
 
@@ -1195,11 +1211,12 @@ function! s:Render() abort
   " are not tracked by the current branch!
   let current_branch = s:get_current_branch()
   let current_branch_remote = s:get_current_branch_remote()
-  exec "syntax match TwiggyCurrent '\\v%3v" . current_branch . "$'"
-  highlight default link TwiggyCurrent Identifier
 
   if g:twiggy_group_locals_by_slash || g:twiggy_group_remotes_by_slash
 	  call ConcealSlashBranches(current_branch, current_branch_remote, g:twiggy_group_locals_by_slash, g:twiggy_group_remotes_by_slash)
+  else
+	  exec "syntax match TwiggyCurrent '\\v%3v" . current_branch . "$'"
+	  highlight default link TwiggyCurrent Identifier
   endif
 
   exec "syntax match TwiggyCurrent '\\V\\%1c" . s:icons.current . "'"

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -268,6 +268,7 @@ function! s:parse_branch(branch, type) abort
     else
       let branch.group = branch_split[0]
       let branch.name  = join(branch_split[1:], '/')
+      let branch.display_name = '(r)' . branch.fullname
     endif
   endif
 
@@ -1178,23 +1179,31 @@ function! s:Render() abort
  
 	if a:conceal_local && !empty(a:current)
 		let parts = split(a:current, '/')
-		if len(parts) < 2 | return | endif
+		if len(parts) < 2 
+			execute("syntax match TwiggySlashCurrent '\\v\\(l\\)" . a:current . "$' contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName")
+			syntax match TwiggySlashCurrentPrefix /\V(l)/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName
+			execute('syntax match TwiggySlashCurrentName /\V' .. a:current .. '/ contained')
+		else
+			execute('syntax match TwiggySlashCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
 
-		let prefix = parts[0] .. '/'
-		let name = join(parts[1 :], '/')
+			let prefix = parts[0] .. '/'
+			let name = join(parts[1 :], '/')
 
-	    " TODO exec "syntax match TwiggySlashCurrent '\\v%6v" . a:conceal_local . "$'"
-		execute('syntax match TwiggySlashCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
-		execute('syntax match TwiggySlashCurrentPrefix /\V(l)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName')
-		execute('syntax match TwiggySlashCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
+			execute('syntax match TwiggySlashCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
+			execute('syntax match TwiggySlashCurrentPrefix /\V(l)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName')
+			execute('syntax match TwiggySlashCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
+		endif
 	endif
 
 	if a:conceal_remote && !empty(a:current_remote)
 		let parts = split(a:current_remote, '/')
-		if len(parts) < 3 | return | endif
-
-		let prefix = join(parts[0 : 1], '/') .. '/'
-		let name = join(parts[2 :], '/')
+		if len(parts) < 3 
+			let prefix = parts[0] .. '/'
+			let name = join(parts[1 :], '/')
+		else
+			let prefix = join(parts[0 : 1], '/') .. '/'
+			let name = join(parts[2 :], '/')
+		endif
 
 		execute('syntax match TwiggySlashCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '/ contains=TwiggySlashCurrentRemotePrefix,TwiggySlashCurrentRemoteName')
 		execute('syntax match TwiggySlashCurrentRemotePrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentRemoteName')

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -73,6 +73,7 @@ else
   let s:icon_set = ['*', '=', '+', '-', '~', '%', 'x']
 endif
 
+let s:ellipsis = has('multi_byte') ? '…' : '...'
 let s:icons = {}
 let s:icons.current  = s:icon_set[0]
 let s:icons.tracking = s:icon_set[1]
@@ -623,11 +624,15 @@ function! s:quickhelp_view() abort
   call add(output, '---------------------------')
   call add(output, 'w/ the cursor on a branch:')
   call add(output, '---------------------------')
+  call add(output, '<CR>  checkout')
   call add(output, 'c     checkout')
   call add(output, 'o     checkout')
-  call add(output, '<CR>  checkout')
+  call add(output, 'cm    checkout --merge')
+  call add(output, 'om    checkout --merge')
   call add(output, 'C     checkout remote')
   call add(output, 'O     checkout remote')
+  call add(output, 'Cm    checkout --merge remote')
+  call add(output, 'Om    checkout --merge remote')
   call add(output, 'gc    checkout as: <name>')
   call add(output, 'go    checkout as: <name>')
   call add(output, 'f     fetch remote')
@@ -664,6 +669,7 @@ function! s:quickhelp_view() abort
   call add(output, 'gi    cycle remote sorts')
   call add(output, 'gI    `gi` in reverse')
   call add(output, 'a     toggle slash-grouping')
+  call add(output, 'ga    toggle slash-grouping remotes')
   if g:twiggy_show_full_ui
     call add(output, '')
     call add(output, '****************************')
@@ -733,8 +739,7 @@ function! s:show_branch_details() abort
 	let status = get(s:branch_line_refs[line], "status", "")
 	let total_len = 8 + strcharlen(decor) + len(msg) + len(name) + len(hash) + len(remote_branch) + len(remote_info)
     if total_len > max_len
-	  let ellipsis = has('multi_byte') ? '…' : '...'
-      let msg = msg[0:max_len + len(msg) - total_len - 1 - strcharlen(ellipsis)] . ellipsis
+      let msg = msg[0:max_len + len(msg) - total_len - 1 - strcharlen(s:ellipsis)] . s:ellipsis
     endif
     redraw
     " Hacky deprecation code
@@ -1133,11 +1138,15 @@ function! s:Render() abort
     nnoremap <buffer> <silent> gg    :normal! 2gg<CR>
   endif
 
-  call s:mapping('<CR>',    'Checkout',         [1])
-  call s:mapping('c',       'Checkout',         [1])
-  call s:mapping('C',       'Checkout',         [0])
-  call s:mapping('o',       'Checkout',         [1])
-  call s:mapping('O',       'Checkout',         [0])
+  call s:mapping('<CR>',    'Checkout',         [1, 0])
+  call s:mapping('c',       'Checkout',         [1, 0])
+  call s:mapping('C',       'Checkout',         [0, 0])
+  call s:mapping('o',       'Checkout',         [1, 0])
+  call s:mapping('O',       'Checkout',         [0, 0])
+  call s:mapping('cm',      'Checkout',         [1, 1])
+  call s:mapping('Cm',      'Checkout',         [0, 1])
+  call s:mapping('om',      'Checkout',         [1, 1])
+  call s:mapping('Om',      'Checkout',         [0, 1])
   call s:mapping('gc',      'CheckoutAs',       [])
   call s:mapping('go',      'CheckoutAs',       [])
   call s:mapping('dd',      'Delete',           [])
@@ -1504,11 +1513,12 @@ endfunction
 
 "   {{{2 Git
 "     {{{3 Checkout
-function! s:Checkout(track) abort
+function! s:Checkout(track, merge) abort
   let current_branch = s:get_current_branch()
   let switch_branch = s:branch_under_cursor()
+  let merge_opt = a:merge ? ' --merge ' : ''
 
-  if s:dirty_tree()
+  if s:dirty_tree() && !a:merge
     let dirty_files = s:git_cmd('diff --name-only', 0)
     let warning = 'error: Your local changes to the following files would be overwritten by checkout:'
     let s:last_output = [
@@ -1529,21 +1539,21 @@ function! s:Checkout(track) abort
     return 1
   else
     redraw
-    echo 'Moving from ' . current_branch . ' to ' . switch_branch.fullname . '...'
+    echo 'Moving from ' . current_branch . ' to ' . switch_branch.fullname . s:ellipsis
     if a:track && !switch_branch.is_local " tracking and branch is remote
       if index(map(s:git_cmd('branch --list', 0), 'v:val[2:]'), switch_branch.name) >= 0
         " Checkout remote in detached HEAD
-        call s:git_cmd('checkout ' . switch_branch.fullname, 0)
+        call s:git_cmd('switch ' . merge_opt . switch_branch.fullname, 0)
       else
         " Create a new tracking branch
-        call s:git_cmd('checkout -b ' . switch_branch.name . ' ' . switch_branch.fullname , 0)
+        call s:git_cmd('switch -c ' . merge_opt . switch_branch.name . ' ' . switch_branch.fullname , 0)
       endif
     elseif !a:track && !switch_branch.is_local " not tracking and branch is remote
-      call s:git_cmd('checkout ' . switch_branch.fullname, 0)
+      call s:git_cmd('switch ' . merge_opt . switch_branch.fullname, 0)
     elseif !a:track && switch_branch.is_local " not tracking and branch is local
-      call s:git_cmd('checkout ' . switch_branch.tracking, 0)
+      call s:git_cmd('switch ' . merge_opt . switch_branch.tracking, 0)
     else " tracking and branch is local
-      call s:git_cmd('checkout ' . switch_branch.fullname, 0)
+      call s:git_cmd('switch ' . merge_opt . switch_branch.fullname, 0)
     endif
   endif
 
@@ -1569,9 +1579,9 @@ function! s:CheckoutAs() abort
       echo branch.name . " already exists."
       return 1
     endif
-    call s:git_cmd("checkout -b " . new_name . " " . branch.fullname, 0)
+    call s:git_cmd("switch -c " . new_name . " " . branch.fullname, 0)
     redraw
-    echo 'Moving from ' . branch.name . ' to ' . new_name . '...'
+    echo 'Moving from ' . branch.name . ' to ' . new_name . s:ellipsis
 
     let s:init_line = 0
     let s:last_branch_under_cursor = 0
@@ -1798,7 +1808,7 @@ function! s:Push(choose_upstream, force) abort
     if !a:force || !g:twiggy_prompted_force_push
       call s:git_cmd(cmd, 1)
     else
-      return s:Confirm("Force push to " . branch.tracking . "?",
+      return s:Confirm("Force push (with lease) to " . branch.tracking . "?",
             \ "s:git_cmd('" . cmd . "', 1)", 0)
     endif
   endif
@@ -1824,7 +1834,7 @@ function! s:Rename() abort
   let new_name = input("Rename " . branch.fullname . " to: ", branch.fullname)
   redraw
   if !empty(new_name)
-	  echo "Renaming \"" . branch.fullname . "\" to \"" . new_name . "\"... "
+	  echo 'Renaming "' . branch.fullname . '" to "' . new_name . '"' . s:ellipsis
 	  call s:git_cmd("branch -m " . branch.fullname . " " . new_name, 0)
 	  call fugitive#ReloadStatus()
   endif

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1389,7 +1389,7 @@ function! s:Render() abort
     syntax match TwiggyHelpHint "\v%1lHelp: "
     highlight default link TwiggyHelpHint fugitiveHelpHeader
     syntax match TwiggyHelpHintKey "\v%1l\?"
-    highlight default link TwiggyHelpHintKey fugitiveHelpHeader
+    highlight default link TwiggyHelpHintKey fugitiveHelpTag
   endif
 
   " }}}

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -724,13 +724,14 @@ function! s:show_branch_details() abort
   let line = line('.')
   if has_key(s:branch_line_refs, line)
     let max_len = &columns - 16
+	let decor = s:branch_line_refs[line].decoration
 	let name = s:branch_line_refs[line].name 
 	let hash = get(s:branch_line_refs[line], "hash", "")
 	let msg = get(s:branch_line_refs[line], "msg", "")
 	let remote_branch = get(s:branch_line_refs[line], "remote_branch", "")
 	let remote_info = get(s:branch_line_refs[line], "remote_info", "")
 	let status = get(s:branch_line_refs[line], "status", "")
-	let total_len = 8 + len(msg) + len(name) + len(hash) + len(remote_branch) + len(remote_info)
+	let total_len = 8 + strcharlen(decor) + len(msg) + len(name) + len(hash) + len(remote_branch) + len(remote_info)
     if total_len > max_len
 	  let ellipsis = has('multi_byte') ? '…' : '...'
       let msg = msg[0:max_len + len(msg) - total_len - 1 - strcharlen(ellipsis)] . ellipsis
@@ -744,9 +745,36 @@ function! s:show_branch_details() abort
       echohl None
       unlet t:twiggy_deprecation_notice
     else
-	  echohl TwiggyBranchCurrentName
+
+	  let icon = trim(decor)
+	  if icon ==# s:icons.current
+		  echohl TwiggyCurrent
+	  elseif icon ==# s:icons.tracking
+		  echohl TwiggyTracking
+	  elseif icon ==# s:icons.ahead
+		  echohl TwiggyAhead
+	  elseif icon ==# s:icons.behind
+		  echohl TwiggyBehind
+	  elseif icon ==# s:icons.both
+		  echohl TwiggyAheadBehind
+	  elseif icon ==# s:icons.detached
+		  echohl TwiggyDetached
+	  elseif icon ==# s:icons.unmerged
+		  echohl TwiggyUnmerged
+	  else
+		  echohl ErrorMsg
+	  endif
+	  echon decor
+	  echohl clear
+
+	  if name =~# '\v^HEAD\@[0-9a-fA-F]+'
+	    echohl TwiggyDetachedText
+	  else
+	    echohl TwiggyBranchCurrentName
+	  endif
 	  echon name 
 	  echohl clear
+
 	  if !empty(hash)
 		  echon ' ('
 		  echohl TwiggyCommitHash
@@ -754,6 +782,7 @@ function! s:show_branch_details() abort
 		  echohl clear
 		  echon ')'
 	  endif
+
 	  if !empty(remote_branch)
 		  echon ' [' 
 		  echohl TwiggyRemote
@@ -773,6 +802,7 @@ function! s:show_branch_details() abort
 		  endif
 		  echon ']'
 	  endif
+
 	  if !empty(msg)
 		  echohl TwiggyCommitMessage
 		  echon ' ' . msg

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1253,11 +1253,10 @@ function! s:Render() abort
 	endif
 	syntax match TwiggyBranchBranchName   /\v[-_[:alnum:].\/]+/ contained
 
-	" remote: match either (r)remote/prefix/name or (r)
+	" remote: match either (r)remote/prefix/name or (r), concealing
+	" '(r)remote/' or '(r)', whichever is longer
 	syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
-	if a:conceal_remote
-		syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)([-_[:alnum:].]+\/){1,2}/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
-	endif
+	syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)([-_[:alnum:].]+\/){1,2}/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
 	syntax match TwiggyBranchRemoteBranchName   /\v[-_[:alnum:].\/]+/ contained
  
 	if a:conceal_local && !empty(a:current)
@@ -1297,8 +1296,8 @@ function! s:Render() abort
 			execute('syntax match TwiggyBranchCurrent' . a:type . 'Name /\V' .. escape(name, '\/\') .. '/ contained')
 		elseif !a:conceal_remote && !empty(a:remote)
 			let parts = split(a:remote, '/')
-			let prefix = ''
-			let name = join(parts[0 :], '/')
+			let prefix = parts[0] .. '/'
+			let name = join(parts[1 :], '/')
 
 			execute('syntax match TwiggyBranchCurrent' . a:type . ' /\v\(r\)' .. escape(a:remote, '\/\') .. '$/ contains=TwiggyBranchCurrent' . a:type . 'Prefix,TwiggyBranchCurrent' . a:type . 'Name')
 			execute('syntax match TwiggyBranchCurrent' . a:type . 'Prefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrent' . a:type . 'Name')

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -62,6 +62,15 @@ let s:requires_buf_refresh     = 1
 let s:sorted      = 0
 let s:git_cmd_run = 0
 
+let s:branch_marker = {
+      \ 'local': '(l)',
+      \ 'remote': '(r)'
+      \ }
+let s:branch_marker_vmagic = {
+      \ 'local': '\(l\)',
+      \ 'remote': '\(r\)'
+      \ }
+
 " {{{1 Icons
 if exists('g:twiggy_icons')
       \ && type(g:twiggy_icons) == 3
@@ -251,11 +260,11 @@ function! s:parse_branch(branch, type) abort
       let group = matchstr(branch.fullname, '\v[^/]*')
       let branch.group = group
       let branch.name = s:sub(branch.fullname, group . '/', '')
-      let branch.display_name = "(l)" . branch.fullname
+      let branch.display_name = s:branch_marker['local'] . branch.fullname
     else
       let branch.group = 'local'
       let branch.name = branch.fullname
-      let branch.display_name = "(l)" . branch.fullname
+      let branch.display_name = s:branch_marker['local'] . branch.fullname
     endif
   else
     let branch.is_local = 0
@@ -267,11 +276,11 @@ function! s:parse_branch(branch, type) abort
       let group = matchstr(branch.name, '\v[^/]*')
       let branch.group = join([branch_split[0], group], '/')
       let branch.name = s:sub(branch.name, group . '/', '')
-      let branch.display_name = '(r)' . branch.fullname
+      let branch.display_name = s:branch_marker['remote'] . branch.fullname
     else
       let branch.group = branch_split[0]
       let branch.name  = join(branch_split[1:], '/')
-      let branch.display_name = '(r)' . branch.fullname
+      let branch.display_name = s:branch_marker['remote'] . branch.fullname
     endif
   endif
 
@@ -1257,43 +1266,43 @@ function! s:Render() abort
     syntax clear TwiggyBranchCurrentPrefix
     syntax clear TwiggyBranchCurrentName
 
-	syntax region TwiggyBranch start=/\v\(l\)/ end=/\v\S+/ contains=TwiggyBranchBranchPrefix,TwiggyBranchBranchName oneline
-	syntax region TwiggyRemoteBranch start=/\v\(r\)/ end=/\v\S+/ contains=TwiggyBranchRemoteBranchPrefix,TwiggyBranchRemoteBranchName oneline
+	execute 'syntax region TwiggyBranch start=/\v' . s:branch_marker_vmagic['local'] . '/ end=/\v\S+/ contains=TwiggyBranchBranchPrefix,TwiggyBranchBranchName oneline'
+	execute 'syntax region TwiggyRemoteBranch start=/\v' . s:branch_marker_vmagic['remote'] . '/ end=/\v\S+/ contains=TwiggyBranchRemoteBranchPrefix,TwiggyBranchRemoteBranchName oneline'
 
-	" local: match either (l)prefix/name or (l)
-	syntax match TwiggyBranchBranchPrefix /\v\(l\)/ contained conceal nextgroup=TwiggyBranchBranchName contains=TwiggyBranchPrefix
+	" local: match either the local marker plus prefix/name or the marker alone
+	execute 'syntax match TwiggyBranchBranchPrefix /\v' . s:branch_marker_vmagic['local'] . '/ contained conceal nextgroup=TwiggyBranchBranchName contains=TwiggyBranchPrefix'
 	if a:conceal_local
-		syntax match TwiggyBranchBranchPrefix /\v\(l\)[-_[:alnum:].]+\// contained conceal nextgroup=TwiggyBranchBranchName contains=TwiggyBranchPrefix
+		execute 'syntax match TwiggyBranchBranchPrefix /\v' . s:branch_marker_vmagic['local'] . '[-_[:alnum:].]+\// contained conceal nextgroup=TwiggyBranchBranchName contains=TwiggyBranchPrefix'
 	endif
 	syntax match TwiggyBranchBranchName   /\v[-_[:alnum:].\/]+/ contained
 
-	" remote: match either (r)remote/prefix/name or (r), concealing
-	" '(r)remote/' or '(r)', whichever is longer
-	syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
+	" remote: match either the remote marker plus remote/prefix/name or the marker alone
+	" concealing the longer prefix when slash grouping is enabled
+	execute 'syntax match TwiggyBranchRemoteBranchPrefix /\v' . s:branch_marker_vmagic['remote'] . '/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix'
 	if a:conceal_remote
-		syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)([-_[:alnum:].]+\/){1,2}/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
+		execute 'syntax match TwiggyBranchRemoteBranchPrefix /\v' . s:branch_marker_vmagic['remote'] . '([-_[:alnum:].]+\/){1,2}/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix'
 	else
-		syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)([-_[:alnum:].]+\/)/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
+		execute 'syntax match TwiggyBranchRemoteBranchPrefix /\v' . s:branch_marker_vmagic['remote'] . '([-_[:alnum:].]+\/)/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix'
 	endif
 	syntax match TwiggyBranchRemoteBranchName   /\v[-_[:alnum:].\/]+/ contained
  
 	if a:conceal_local && !empty(a:current)
 		let parts = split(a:current, '/')
 		if len(parts) < 2 
-			execute("syntax match TwiggyBranchCurrent '\\v\\(l\\)" . a:current . "$' contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName")
-			syntax match TwiggyBranchCurrentPrefix /\V(l)/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentName
+			execute("syntax match TwiggyBranchCurrent '\\v" . s:branch_marker_vmagic['local'] . a:current . "$' contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName")
+			execute 'syntax match TwiggyBranchCurrentPrefix /\V' . escape(s:branch_marker['local'], '\/') . '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentName'
 			execute('syntax match TwiggyBranchCurrentName /\V' .. a:current .. '/ contained')
 		else
 			let prefix = parts[0] .. '/'
 			let name = join(parts[1 :], '/')
 
-			execute('syntax match TwiggyBranchCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '$/ contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName')
-			execute('syntax match TwiggyBranchCurrentPrefix /\V(l)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentName')
+			execute('syntax match TwiggyBranchCurrent /\v' .. s:branch_marker_vmagic['local'] .. escape(a:current, '\/\') .. '$/ contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName')
+			execute('syntax match TwiggyBranchCurrentPrefix /\V' .. escape(s:branch_marker['local'] . prefix, '\/') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentName')
 			execute('syntax match TwiggyBranchCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
 		endif
 	elseif !a:conceal_local && !empty(a:current)
-		execute('syntax match TwiggyBranchCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '$/ contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName')
-		syntax match TwiggyBranchCurrentPrefix /\V(l)/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentName
+		execute('syntax match TwiggyBranchCurrent /\v' .. s:branch_marker_vmagic['local'] .. escape(a:current, '\/\') .. '$/ contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName')
+		execute 'syntax match TwiggyBranchCurrentPrefix /\V' . escape(s:branch_marker['local'], '\/') . '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentName'
 		echom a:current
 		execute('syntax match TwiggyBranchCurrentName /\V' .. escape(a:current, '\/\') .. '/ contained')
 	endif
@@ -1309,16 +1318,16 @@ function! s:Render() abort
 				let name = join(parts[2 :], '/')
 			endif
 
-			execute('syntax match TwiggyBranchCurrent' . a:type . ' /\v\(r\)' .. escape(a:remote, '\/\') .. '$/ contains=TwiggyBranchCurrent' . a:type . 'Prefix,TwiggyBranchCurrent' . a:type . 'Name')
-			execute('syntax match TwiggyBranchCurrent' . a:type . 'Prefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrent' . a:type . 'Name')
+			execute('syntax match TwiggyBranchCurrent' . a:type . ' /\v' .. s:branch_marker_vmagic['remote'] .. escape(a:remote, '\/\') .. '$/ contains=TwiggyBranchCurrent' . a:type . 'Prefix,TwiggyBranchCurrent' . a:type . 'Name')
+			execute('syntax match TwiggyBranchCurrent' . a:type . 'Prefix /\V' .. escape(s:branch_marker['remote'] . prefix, '\/') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrent' . a:type . 'Name')
 			execute('syntax match TwiggyBranchCurrent' . a:type . 'Name /\V' .. escape(name, '\/\') .. '/ contained')
 		elseif !a:conceal_remote && !empty(a:remote)
 			let parts = split(a:remote, '/')
 			let prefix = parts[0] .. '/'
 			let name = join(parts[1 :], '/')
 
-			execute('syntax match TwiggyBranchCurrent' . a:type . ' /\v\(r\)' .. escape(a:remote, '\/\') .. '$/ contains=TwiggyBranchCurrent' . a:type . 'Prefix,TwiggyBranchCurrent' . a:type . 'Name')
-			execute('syntax match TwiggyBranchCurrent' . a:type . 'Prefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrent' . a:type . 'Name')
+			execute('syntax match TwiggyBranchCurrent' . a:type . ' /\v' .. s:branch_marker_vmagic['remote'] .. escape(a:remote, '\/\') .. '$/ contains=TwiggyBranchCurrent' . a:type . 'Prefix,TwiggyBranchCurrent' . a:type . 'Name')
+			execute('syntax match TwiggyBranchCurrent' . a:type . 'Prefix /\V' .. escape(s:branch_marker['remote'] . prefix, '\/') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrent' . a:type . 'Name')
 			execute('syntax match TwiggyBranchCurrent' . a:type . 'Name /\V' .. escape(name, '\/\') .. '/ contained')
 		endif
 
@@ -1331,31 +1340,8 @@ function! s:Render() abort
 		call RenderRemote(a:conceal_remote, a:push, "Push")
 	endif
 
-	" if a:conceal_remote && !empty(a:upstream)
-	" 	let parts = split(a:upstream, '/')
-	" 	if len(parts) < 3 
-	" 		let prefix = parts[0] .. '/'
-	" 		let name = join(parts[1 :], '/')
-	" 	else
-	" 		let prefix = join(parts[0 : 1], '/') .. '/'
-	" 		let name = join(parts[2 :], '/')
-	" 	endif
-
-	" 	execute('syntax match TwiggyBranchCurrentUpstream /\v\(r\)' .. escape(a:upstream, '\/\') .. '$/ contains=TwiggyBranchCurrentUpstreamPrefix,TwiggyBranchCurrentUpstreamName')
-	" 	execute('syntax match TwiggyBranchCurrentUpstreamPrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentUpstreamName')
-	" 	execute('syntax match TwiggyBranchCurrentUpstreamName /\V' .. escape(name, '\/\') .. '/ contained')
-	" elseif !a:conceal_remote && !empty(a:upstream)
-	" 	let parts = split(a:upstream, '/')
-	" 	let prefix = ''
-	" 	let name = join(parts[0 :], '/')
-
-	" 	execute('syntax match TwiggyBranchCurrentUpstream /\v\(r\)' .. escape(a:upstream, '\/\') .. '$/ contains=TwiggyBranchCurrentUpstreamPrefix,TwiggyBranchCurrentUpstreamName')
-	" 	execute('syntax match TwiggyBranchCurrentUpstreamPrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentUpstreamName')
-	" 	execute('syntax match TwiggyBranchCurrentUpstreamName /\V' .. escape(name, '\/\') .. '/ contained')
-	" endif
-
-	syntax match TwiggyBranchPrefix /\v\(l\)/ contained conceal
-	syntax match TwiggyBranchPrefix /\v\(r\)/ contained conceal
+	execute 'syntax match TwiggyBranchPrefix /\v' . s:branch_marker_vmagic['local'] . '/ contained conceal'
+	execute 'syntax match TwiggyBranchPrefix /\v' . s:branch_marker_vmagic['remote'] . '/ contained conceal'
   endfunction
 
   let current_branch = s:get_current_branch()

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -9,6 +9,8 @@ if exists('g:autoloaded_twiggy')
 endif
 let g:autoloaded_twiggy = 1
 
+highlight default link TwiggyCommitMsg Normal
+
 " {{{1 Utility
 "   {{{2 buffocus
 function! s:buffocus(bufnr) abort
@@ -746,7 +748,7 @@ function! s:show_branch_details() abort
 	  echon name 
 	  echohl clear
 	  echon ' ('
-	  echohl TwiggyGitHash
+	  echohl TwiggyCommitHash
 	  echon hash
 	  echohl clear
 	  echon ')'
@@ -769,7 +771,9 @@ function! s:show_branch_details() abort
 		  endif
 		  echon ']'
 	  endif
+	  echohl TwiggyCommitMessage
       echon ' ' . msg
+	  echohl clear
 	  echon
     endif
   end
@@ -1045,7 +1049,7 @@ function! s:Render() abort
     return
   endif
 
-  highlight default link TwiggyGitHash fugitiveHash
+  highlight default link TwiggyCommitHash fugitiveHash
   highlight default link TwiggyRemote fugitiveSymbolicRef
   call s:show_branch_details()
   let s:total_lines = len(output)

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1256,7 +1256,11 @@ function! s:Render() abort
 	" remote: match either (r)remote/prefix/name or (r), concealing
 	" '(r)remote/' or '(r)', whichever is longer
 	syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
-	syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)([-_[:alnum:].]+\/){1,2}/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
+	if a:conceal_remote
+		syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)([-_[:alnum:].]+\/){1,2}/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
+	else
+		syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)([-_[:alnum:].]+\/)/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
+	endif
 	syntax match TwiggyBranchRemoteBranchName   /\v[-_[:alnum:].\/]+/ contained
  
 	if a:conceal_local && !empty(a:current)

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -248,6 +248,7 @@ function! s:parse_branch(branch, type) abort
       let group = matchstr(branch.fullname, '\v[^/]*')
       let branch.group = group
       let branch.name = s:sub(branch.fullname, group . '/', '')
+      let branch.display_name = "(l)" . branch.fullname
     else
       let branch.group = 'local'
       let branch.name = branch.fullname
@@ -262,10 +263,15 @@ function! s:parse_branch(branch, type) abort
       let group = matchstr(branch.name, '\v[^/]*')
       let branch.group = join([branch_split[0], group], '/')
       let branch.name = s:sub(branch.name, group . '/', '')
+      let branch.display_name = '(r)' . branch.fullname
     else
       let branch.group = branch_split[0]
       let branch.name  = join(branch_split[1:], '/')
     endif
+  endif
+
+  if !has_key(branch, 'display_name')
+	  let branch.display_name = branch.name
   endif
 
   let remote_details = pieces[3]
@@ -555,7 +561,7 @@ function! s:standard_view() abort
       call add(output, group_ref.name . ' [' . sort_name . ']')
 
       for branch in group_ref['branches']
-        call add(output, branch.decoration . branch.name)
+        call add(output, branch.decoration . get(branch, 'display_name', branch.name))
         let line = line + 1
         let branch.line = line
         let s:branch_line_refs[line] = branch
@@ -1104,9 +1110,66 @@ function! s:Render() abort
 
   exec "syntax match TwiggyGroup '\\v(^[^\\ " . s:icons.current . "]+)'"
   highlight default link TwiggyGroup Type
+  
+    hi def link TwiggySlash Comment
+    hi def link TwiggySlashPrefix Comment
+    hi def link TwiggySlashCurrentPrefix Comment
+    hi def link TwiggySlashCurrentName TwiggyCurrent
+    highlight default link TwiggySlashCurrent Identifier
+	" highlight link TwiggySlashBranchName Normal
 
-  exec "syntax match TwiggyCurrent '\\v%3v" . s:get_current_branch() . "$'"
+  " ────────────────────────────────────────────────────────────────────────
+  " Conceal slash prefix
+  " ────────────────────────────────────────────────────────────────────────
+  function! ConcealSlashBranches(current, conceal_local, conceal_remote)
+    syntax clear TwiggySlash
+    syntax clear TwiggySlashPrefix
+    syntax clear TwiggySlashCurrent
+    syntax clear TwiggySlashCurrentPrefix
+    syntax clear TwiggySlashCurrentName
+
+	let slash_prefix = ''
+	if a:conceal_local && a:conceal_remote
+		let slash_prefix = '([lr])'
+	elseif a:conceal_local
+		let slash_prefix = '(l)'
+	elseif a:conceal_remote
+		let slash_prefix = '(r)'
+	endif
+
+	execute('syntax region TwiggySlash start=/\v' . escape(slash_prefix, '()') . '[-_[:alnum:].]+\// end=/\v[()-_[:alnum:].\/]+/ contains=TwiggySlashPrefix,TwiggySlashBranchPrefix,TwiggySlashBranchName oneline')
+
+	syntax match TwiggySlashBranchName   /\v[-_[:alnum:].\/]+/ contained
+	syntax match TwiggySlashBranchPrefix /\v[-_[:alnum:].]+\// contained conceal
+
+    let parts = split(a:current, '/')
+    if len(parts) < 2
+      return
+    endif
+  
+    let prefix = parts[0] .. '/'
+    let name = join(parts[1 :], '/')
+
+	if a:conceal_local
+		execute('syntax match TwiggySlashCurrent /\v' .. escape(slash_prefix, '()') .. escape(a:current, '\/\') .. '/ contains=TwiggySlashPrefix,TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
+		execute('syntax match TwiggySlashCurrentPrefix /\V' .. escape(prefix, '\/\') .. '/ contained conceal nextgroup=TwiggySlashCurrentName')
+		execute('syntax match TwiggySlashCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
+	endif
+
+	echom 'syntax match TwiggySlashPrefix /\v' . escape(slash_prefix, '()') . '/ contained conceal'
+	execute('syntax match TwiggySlashPrefix /\v' . escape(slash_prefix, '()') . '/ contained conceal')
+  
+    let &l:conceallevel = 2
+    let &l:concealcursor = 'nvic'
+  endfunction
+
+  let current_branch = s:get_current_branch()
+  exec "syntax match TwiggyCurrent '\\v%3v" . current_branch . "$'"
   highlight default link TwiggyCurrent Identifier
+
+  if g:twiggy_group_locals_by_slash || g:twiggy_group_remotes_by_slash
+	  call ConcealSlashBranches(current_branch, g:twiggy_group_locals_by_slash, g:twiggy_group_remotes_by_slash)
+  endif
 
   exec "syntax match TwiggyCurrent '\\V\\%1c" . s:icons.current . "'"
   highlight default link TwiggyCurrent Identifier

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1424,7 +1424,7 @@ function! s:Quickhelp() abort
   setlocal nomodifiable
 
   syntax clear
-  syntax match TwiggyQuickhelpMapping "\v%<7c[A-Za-z\-\?\^\<\>!,.]"
+  syntax match TwiggyQuickhelpMapping "\v%<9c[A-Za-z\-\?\^\<\>!,.]"
   highlight link TwiggyQuickhelpMapping Identifier
   syntax match TwiggyQuickhelpSpecial "\v\`[a-zA-Z]+\`"
   highlight link TwiggyQuickhelpSpecial Identifier

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1120,81 +1120,58 @@ function! s:Render() abort
   exec "syntax match TwiggyGroup '\\v(^[^\\ " . s:icons.current . "]+)'"
   highlight default link TwiggyGroup Type
   
-    hi def link TwiggySlash Comment
-    hi def link TwiggyRemoteSlash Comment
-    hi def link TwiggySlashPrefix Comment
-    hi def link TwiggySlashCurrentPrefix Comment
-    hi def link TwiggySlashCurrentName TwiggyCurrent
-    hi def link TwiggySlashCurrentRemoteName TwiggyCurrent
-    highlight default link TwiggySlashCurrent Identifier
-	" highlight link TwiggySlashBranchName Normal
+  highlight default link TwiggyBranch Comment
+  highlight default link TwiggyRemoteBranch Comment
+  highlight default link TwiggyBranchPrefix Comment
+  highlight default link TwiggyBranchCurrentPrefix Comment
+  highlight default link TwiggyBranchCurrentName TwiggyCurrent
+  highlight default link TwiggyBranchCurrentRemoteName TwiggyCurrent
+  highlight default link TwiggyBranchCurrent Identifier
 
   " ────────────────────────────────────────────────────────────────────────
-  " Conceal slash prefix
-  "
-  " TODO: this still relies on TwiggyCurrent when there is no slash in the
-  " name!
-  "
-  " TODO: this only implements rendering branches for slash sorting, we need to
-  " implement it for non-slash sorting too
+  " Render Branches w/ and w/o slash sorting
   " ────────────────────────────────────────────────────────────────────────
   let &l:conceallevel = 2
   let &l:concealcursor = 'nvic'
+  function! RenderBranches(current, current_remote, conceal_local, conceal_remote)
+    syntax clear TwiggyBranch
+    syntax clear TwiggyRemoteBranch
+    syntax clear TwiggyBranchPrefix
+    syntax clear TwiggyBranchCurrent
+    syntax clear TwiggyBranchCurrentPrefix
+    syntax clear TwiggyBranchCurrentName
 
-  function! ConcealSlashBranches(current, current_remote, conceal_local, conceal_remote)
-    syntax clear TwiggySlash
-    syntax clear TwiggyRemoteSlash
-    syntax clear TwiggySlashPrefix
-    syntax clear TwiggySlashCurrent
-    syntax clear TwiggySlashCurrentPrefix
-    syntax clear TwiggySlashCurrentName
-
-	" let slash_prefix = ''
-	" if a:conceal_local && a:conceal_remote
-	" 	let slash_prefix = '([lr])'
-	" 	let slash_prefix_very_nomagic = '(l\|r)'
-	" elseif a:conceal_local
-	" 	let slash_prefix = '(l)'
-	" 	let slash_prefix_very_nomagic = slash_prefix
-	" elseif a:conceal_remote
-	" 	let slash_prefix = '(r)'
-	" 	let slash_prefix_very_nomagic = slash_prefix
-	" endif
-
-	" execute('syntax region TwiggySlash start=/\v' . escape(slash_prefix, '()') . '[-_[:alnum:].]+\// end=/\v[()-_[:alnum:].\/]+/ contains=TwiggySlashBranchPrefix,TwiggySlashBranchName oneline')
-	" execute('syntax region TwiggySlash start=/\V' . slash_prefix_very_nomagic . '/ end=/\v\S+/ contains=TwiggySlashBranchPrefix,TwiggySlashBranchName,TwiggySlashRemoteBranchPrefix,TwiggySlashRemoteBranchName oneline')
-	" syntax region TwiggySlash start=/\v\([lr]\)/ end=/\v\S+/ contains=TwiggySlashBranchPrefix,TwiggySlashBranchName,TwiggySlashRemoteBranchPrefix,TwiggySlashRemoteBranchName oneline
-	syntax region TwiggySlash start=/\v\(l\)/ end=/\v\S+/ contains=TwiggySlashBranchPrefix,TwiggySlashBranchName oneline
-	syntax region TwiggyRemoteSlash start=/\v\(r\)/ end=/\v\S+/ contains=TwiggySlashRemoteBranchPrefix,TwiggySlashRemoteBranchName oneline
+	syntax region TwiggyBranch start=/\v\(l\)/ end=/\v\S+/ contains=TwiggyBranchBranchPrefix,TwiggyBranchBranchName oneline
+	syntax region TwiggyRemoteBranch start=/\v\(r\)/ end=/\v\S+/ contains=TwiggyBranchRemoteBranchPrefix,TwiggyBranchRemoteBranchName oneline
 
 	" local: match either (l)prefix/name or (l)
-	syntax match TwiggySlashBranchPrefix /\v\(l\)[-_[:alnum:].]+\// contained conceal nextgroup=TwiggySlashBranchName contains=TwiggySlashPrefix
-	syntax match TwiggySlashBranchPrefix /\v\(l\)/ contained conceal nextgroup=TwiggySlashBranchName contains=TwiggySlashPrefix
-	syntax match TwiggySlashBranchName   /\v[-_[:alnum:].\/]+/ contained
+	syntax match TwiggyBranchBranchPrefix /\v\(l\)[-_[:alnum:].]+\// contained conceal nextgroup=TwiggyBranchBranchName contains=TwiggyBranchPrefix
+	syntax match TwiggyBranchBranchPrefix /\v\(l\)/ contained conceal nextgroup=TwiggyBranchBranchName contains=TwiggyBranchPrefix
+	syntax match TwiggyBranchBranchName   /\v[-_[:alnum:].\/]+/ contained
 
 	" remote: match either (r)remote/prefix/name or (r)
-	syntax match TwiggySlashRemoteBranchPrefix /\v\(r\)/ contained conceal nextgroup=TwiggySlashRemoteBranchName contains=TwiggySlashPrefix
-	syntax match TwiggySlashRemoteBranchPrefix /\v\(r\)([-_[:alnum:].]+\/){1,2}/ contained conceal nextgroup=TwiggySlashRemoteBranchName contains=TwiggySlashPrefix
-	syntax match TwiggySlashRemoteBranchName   /\v[-_[:alnum:].\/]+/ contained
+	syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
+	syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)([-_[:alnum:].]+\/){1,2}/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
+	syntax match TwiggyBranchRemoteBranchName   /\v[-_[:alnum:].\/]+/ contained
  
 	if a:conceal_local && !empty(a:current)
 		let parts = split(a:current, '/')
 		if len(parts) < 2 
-			execute("syntax match TwiggySlashCurrent '\\v\\(l\\)" . a:current . "$' contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName")
-			syntax match TwiggySlashCurrentPrefix /\V(l)/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName
-			execute('syntax match TwiggySlashCurrentName /\V' .. a:current .. '/ contained')
+			execute("syntax match TwiggyBranchCurrent '\\v\\(l\\)" . a:current . "$' contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName")
+			syntax match TwiggyBranchCurrentPrefix /\V(l)/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentName
+			execute('syntax match TwiggyBranchCurrentName /\V' .. a:current .. '/ contained')
 		else
 			let prefix = parts[0] .. '/'
 			let name = join(parts[1 :], '/')
 
-			execute('syntax match TwiggySlashCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
-			execute('syntax match TwiggySlashCurrentPrefix /\V(l)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName')
-			execute('syntax match TwiggySlashCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
+			execute('syntax match TwiggyBranchCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName')
+			execute('syntax match TwiggyBranchCurrentPrefix /\V(l)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentName')
+			execute('syntax match TwiggyBranchCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
 		endif
 	elseif !a:conceal_local && !empty(a:current)
-		execute('syntax match TwiggySlashCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
-		syntax match TwiggySlashCurrentPrefix /\V(l)/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName
-		execute('syntax match TwiggySlashCurrentName /\V' .. escape(a:current, '\/\') .. '/ contained')
+		execute('syntax match TwiggyBranchCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName')
+		syntax match TwiggyBranchCurrentPrefix /\V(l)/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentName
+		execute('syntax match TwiggyBranchCurrentName /\V' .. escape(a:current, '\/\') .. '/ contained')
 	endif
 
 	if a:conceal_remote && !empty(a:current_remote)
@@ -1207,28 +1184,27 @@ function! s:Render() abort
 			let name = join(parts[2 :], '/')
 		endif
 
-		execute('syntax match TwiggySlashCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '/ contains=TwiggySlashCurrentRemotePrefix,TwiggySlashCurrentRemoteName')
-		execute('syntax match TwiggySlashCurrentRemotePrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentRemoteName')
-		execute('syntax match TwiggySlashCurrentRemoteName /\V' .. escape(name, '\/\') .. '/ contained')
+		execute('syntax match TwiggyBranchCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '/ contains=TwiggyBranchCurrentRemotePrefix,TwiggyBranchCurrentRemoteName')
+		execute('syntax match TwiggyBranchCurrentRemotePrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentRemoteName')
+		execute('syntax match TwiggyBranchCurrentRemoteName /\V' .. escape(name, '\/\') .. '/ contained')
 	elseif !a:conceal_remote && !empty(a:current_remote)
 		let parts = split(a:current_remote, '/')
 		let prefix = parts[0] .. '/'
 		let name = join(parts[1 :], '/')
 
-		execute('syntax match TwiggySlashCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '/ contains=TwiggySlashCurrentRemotePrefix,TwiggySlashCurrentRemoteName')
-		execute('syntax match TwiggySlashCurrentRemotePrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentRemoteName')
-		execute('syntax match TwiggySlashCurrentRemoteName /\V' .. escape(name, '\/\') .. '/ contained')
+		execute('syntax match TwiggyBranchCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '/ contains=TwiggyBranchCurrentRemotePrefix,TwiggyBranchCurrentRemoteName')
+		execute('syntax match TwiggyBranchCurrentRemotePrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentRemoteName')
+		execute('syntax match TwiggyBranchCurrentRemoteName /\V' .. escape(name, '\/\') .. '/ contained')
 	endif
 
-	" execute('syntax match TwiggySlashPrefix /\v' . escape(slash_prefix, '()') . '/ contained conceal')
-	syntax match TwiggySlashPrefix /\v\(l\)/ contained conceal
-	syntax match TwiggySlashPrefix /\v\(r\)/ contained conceal
-  
+	syntax match TwiggyBranchPrefix /\v\(l\)/ contained conceal
+	syntax match TwiggyBranchPrefix /\v\(r\)/ contained conceal
   endfunction
 
   let current_branch = s:get_current_branch()
   let current_branch_remote = s:get_current_branch_remote()
-  call ConcealSlashBranches(current_branch, current_branch_remote, g:twiggy_group_locals_by_slash, g:twiggy_group_remotes_by_slash)
+  call RenderBranches(current_branch, current_branch_remote, g:twiggy_group_locals_by_slash, g:twiggy_group_remotes_by_slash)
+  " ────────────────────────────────────────────────────────────────────────
 
   exec "syntax match TwiggyCurrent '\\V\\%1c" . s:icons.current . "'"
   highlight default link TwiggyCurrent Identifier

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1204,9 +1204,10 @@ function! s:Render() abort
   highlight default link TwiggyBranch Comment
   highlight default link TwiggyRemoteBranch Comment
   highlight default link TwiggyBranchPrefix Comment
+  highlight default link TwiggyBranchBranchPrefix Comment
   highlight default link TwiggyBranchCurrentPrefix Comment
   highlight default link TwiggyBranchCurrentName TwiggyCurrent
-  highlight default link TwiggyBranchCurrentRemoteName TwiggyCurrent
+  highlight default link TwiggyBranchCurrentRemoteName TwiggyRemote
   highlight default link TwiggyBranchCurrent Identifier
 
   " ────────────────────────────────────────────────────────────────────────
@@ -1226,13 +1227,17 @@ function! s:Render() abort
 	syntax region TwiggyRemoteBranch start=/\v\(r\)/ end=/\v\S+/ contains=TwiggyBranchRemoteBranchPrefix,TwiggyBranchRemoteBranchName oneline
 
 	" local: match either (l)prefix/name or (l)
-	syntax match TwiggyBranchBranchPrefix /\v\(l\)[-_[:alnum:].]+\// contained conceal nextgroup=TwiggyBranchBranchName contains=TwiggyBranchPrefix
 	syntax match TwiggyBranchBranchPrefix /\v\(l\)/ contained conceal nextgroup=TwiggyBranchBranchName contains=TwiggyBranchPrefix
+	if a:conceal_local
+		syntax match TwiggyBranchBranchPrefix /\v\(l\)[-_[:alnum:].]+\// contained conceal nextgroup=TwiggyBranchBranchName contains=TwiggyBranchPrefix
+	endif
 	syntax match TwiggyBranchBranchName   /\v[-_[:alnum:].\/]+/ contained
 
 	" remote: match either (r)remote/prefix/name or (r)
 	syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
-	syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)([-_[:alnum:].]+\/){1,2}/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
+	if a:conceal_remote
+		syntax match TwiggyBranchRemoteBranchPrefix /\v\(r\)([-_[:alnum:].]+\/){1,2}/ contained conceal nextgroup=TwiggyBranchRemoteBranchName contains=TwiggyBranchPrefix
+	endif
 	syntax match TwiggyBranchRemoteBranchName   /\v[-_[:alnum:].\/]+/ contained
  
 	if a:conceal_local && !empty(a:current)

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -455,9 +455,16 @@ function! s:get_current_branch() abort
   return s:git_cmd('rev-parse --abbrev-ref HEAD', 0)[0]
 endfunction
 
-"   {{{2 get_current_branch_remote
-function! s:get_current_branch_remote() abort
+"   {{{2 get_current_branch_remote_upstream
+function! s:get_current_branch_remote_upstream() abort
   let remote = s:git_cmd('rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null', 0)
+  if empty(remote) | return "" | endif
+  return remote[0]
+endfunction
+
+"   {{{2 get_current_branch_remote_push
+function! s:get_current_branch_remote_push() abort
+  let remote = s:git_cmd('rev-parse --abbrev-ref --symbolic-full-name @{push} 2>/dev/null', 0)
   if empty(remote) | return "" | endif
   return remote[0]
 endfunction
@@ -791,7 +798,7 @@ function! s:show_branch_details() abort
 
 	  if !empty(remote_branch)
 		  echon ' [' 
-		  echohl TwiggyRemote
+		  echohl TwiggyUpstream
 		  echon remote_branch
 		  echohl clear
 		  if !empty(remote_info)
@@ -1090,7 +1097,9 @@ function! s:Render() abort
   endif
 
   highlight default link TwiggyCommitHash fugitiveHash
-  highlight default link TwiggyRemote fugitiveSymbolicRef
+  highlight default link TwiggyUpstreamPush Directory
+  highlight default link TwiggyPush Error
+  highlight default link TwiggyUpstream fugitiveSymbolicRef
   call s:show_branch_details()
   let s:total_lines = len(output)
 
@@ -1216,7 +1225,9 @@ function! s:Render() abort
   highlight default link TwiggyBranchBranchPrefix Comment
   highlight default link TwiggyBranchCurrentPrefix Comment
   highlight default link TwiggyBranchCurrentName TwiggyCurrent
-  highlight default link TwiggyBranchCurrentRemoteName TwiggyRemote
+  highlight default link TwiggyBranchCurrentUpstreamName TwiggyUpstream
+  highlight default link TwiggyBranchCurrentPushName TwiggyPush
+  highlight default link TwiggyBranchCurrentUpstreamPushName TwiggyUpstreamPush
   highlight default link TwiggyBranchCurrent Identifier
 
   " ────────────────────────────────────────────────────────────────────────
@@ -1224,7 +1235,7 @@ function! s:Render() abort
   " ────────────────────────────────────────────────────────────────────────
   let &l:conceallevel = 2
   let &l:concealcursor = 'nvic'
-  function! RenderBranches(current, current_remote, conceal_local, conceal_remote)
+  function! RenderBranches(current, upstream, push, conceal_local, conceal_remote)
     syntax clear TwiggyBranch
     syntax clear TwiggyRemoteBranch
     syntax clear TwiggyBranchPrefix
@@ -1270,36 +1281,70 @@ function! s:Render() abort
 		execute('syntax match TwiggyBranchCurrentName /\V' .. escape(a:current, '\/\') .. '/ contained')
 	endif
 
-	if a:conceal_remote && !empty(a:current_remote)
-		let parts = split(a:current_remote, '/')
-		if len(parts) < 3 
-			let prefix = parts[0] .. '/'
-			let name = join(parts[1 :], '/')
-		else
-			let prefix = join(parts[0 : 1], '/') .. '/'
-			let name = join(parts[2 :], '/')
+	function! RenderRemote(conceal_remote, remote, type)
+		if a:conceal_remote && !empty(a:remote)
+			let parts = split(a:remote, '/')
+			if len(parts) < 3 
+				let prefix = parts[0] .. '/'
+				let name = join(parts[1 :], '/')
+			else
+				let prefix = join(parts[0 : 1], '/') .. '/'
+				let name = join(parts[2 :], '/')
+			endif
+
+			execute('syntax match TwiggyBranchCurrent' . a:type . ' /\v\(r\)' .. escape(a:remote, '\/\') .. '$/ contains=TwiggyBranchCurrent' . a:type . 'Prefix,TwiggyBranchCurrent' . a:type . 'Name')
+			execute('syntax match TwiggyBranchCurrent' . a:type . 'Prefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrent' . a:type . 'Name')
+			execute('syntax match TwiggyBranchCurrent' . a:type . 'Name /\V' .. escape(name, '\/\') .. '/ contained')
+		elseif !a:conceal_remote && !empty(a:remote)
+			let parts = split(a:remote, '/')
+			let prefix = ''
+			let name = join(parts[0 :], '/')
+
+			execute('syntax match TwiggyBranchCurrent' . a:type . ' /\v\(r\)' .. escape(a:remote, '\/\') .. '$/ contains=TwiggyBranchCurrent' . a:type . 'Prefix,TwiggyBranchCurrent' . a:type . 'Name')
+			execute('syntax match TwiggyBranchCurrent' . a:type . 'Prefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrent' . a:type . 'Name')
+			execute('syntax match TwiggyBranchCurrent' . a:type . 'Name /\V' .. escape(name, '\/\') .. '/ contained')
 		endif
 
-		execute('syntax match TwiggyBranchCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '$/ contains=TwiggyBranchCurrentRemotePrefix,TwiggyBranchCurrentRemoteName')
-		execute('syntax match TwiggyBranchCurrentRemotePrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentRemoteName')
-		execute('syntax match TwiggyBranchCurrentRemoteName /\V' .. escape(name, '\/\') .. '/ contained')
-	elseif !a:conceal_remote && !empty(a:current_remote)
-		let parts = split(a:current_remote, '/')
-		let prefix = parts[0] .. '/'
-		let name = join(parts[1 :], '/')
+	endfunction
 
-		execute('syntax match TwiggyBranchCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '$/ contains=TwiggyBranchCurrentRemotePrefix,TwiggyBranchCurrentRemoteName')
-		execute('syntax match TwiggyBranchCurrentRemotePrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentRemoteName')
-		execute('syntax match TwiggyBranchCurrentRemoteName /\V' .. escape(name, '\/\') .. '/ contained')
+	if a:upstream ==# a:push
+		call RenderRemote(a:conceal_remote, a:upstream, "UpstreamPush")
+	else
+		call RenderRemote(a:conceal_remote, a:upstream, "Upstream")
+		call RenderRemote(a:conceal_remote, a:push, "Push")
 	endif
+
+	" if a:conceal_remote && !empty(a:upstream)
+	" 	let parts = split(a:upstream, '/')
+	" 	if len(parts) < 3 
+	" 		let prefix = parts[0] .. '/'
+	" 		let name = join(parts[1 :], '/')
+	" 	else
+	" 		let prefix = join(parts[0 : 1], '/') .. '/'
+	" 		let name = join(parts[2 :], '/')
+	" 	endif
+
+	" 	execute('syntax match TwiggyBranchCurrentUpstream /\v\(r\)' .. escape(a:upstream, '\/\') .. '$/ contains=TwiggyBranchCurrentUpstreamPrefix,TwiggyBranchCurrentUpstreamName')
+	" 	execute('syntax match TwiggyBranchCurrentUpstreamPrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentUpstreamName')
+	" 	execute('syntax match TwiggyBranchCurrentUpstreamName /\V' .. escape(name, '\/\') .. '/ contained')
+	" elseif !a:conceal_remote && !empty(a:upstream)
+	" 	let parts = split(a:upstream, '/')
+	" 	let prefix = ''
+	" 	let name = join(parts[0 :], '/')
+
+	" 	execute('syntax match TwiggyBranchCurrentUpstream /\v\(r\)' .. escape(a:upstream, '\/\') .. '$/ contains=TwiggyBranchCurrentUpstreamPrefix,TwiggyBranchCurrentUpstreamName')
+	" 	execute('syntax match TwiggyBranchCurrentUpstreamPrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentUpstreamName')
+	" 	execute('syntax match TwiggyBranchCurrentUpstreamName /\V' .. escape(name, '\/\') .. '/ contained')
+	" endif
 
 	syntax match TwiggyBranchPrefix /\v\(l\)/ contained conceal
 	syntax match TwiggyBranchPrefix /\v\(r\)/ contained conceal
   endfunction
 
   let current_branch = s:get_current_branch()
-  let current_branch_remote = s:get_current_branch_remote()
-  call RenderBranches(current_branch, current_branch_remote, g:twiggy_group_locals_by_slash, g:twiggy_group_remotes_by_slash)
+  let upstream = s:get_current_branch_remote_upstream()
+  let push = s:get_current_branch_remote_push()
+  call RenderBranches(current_branch, upstream, push, g:twiggy_group_locals_by_slash, g:twiggy_group_remotes_by_slash)
   " ────────────────────────────────────────────────────────────────────────
 
   exec "syntax match TwiggyCurrent '\\V\\%1c" . s:icons.current . "'"
@@ -1722,7 +1767,7 @@ function! s:Continue(type) abort
   if a:type ==? 'stash'
       call s:ContinueStash()
   else
-    call s:git_cmd(a:type . ' --continue', 1, {"no_dispatch": 1})
+    call s:git_cmd(a:type . ' --continue', 1, {"no_dispatch": 0})
   endif
 
   redraw
@@ -1751,7 +1796,7 @@ endfunction
 
 "     {{{3 Stash Continue
 function! s:ContinueStash() abort
-  call s:git_cmd('commit', 1, {"no_dispatch": 1})
+  call s:git_cmd('commit', 1, {"no_dispatch": 0})
 endfunction
 
 "     {{{3 Stash Abort

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -625,7 +625,9 @@ function! s:quickhelp_view() abort
   call add(output, '<space>R  Refresh')
   call add(output, '<C-N>	  jump to next group')
   call add(output, '<C-P>	  jump to prev group')
-  call add(output, 'J         jump to curr branch')
+  call add(output, 'JL        jump to curr branch')
+  call add(output, 'JU        jump to curr upstream')
+  call add(output, 'JP        jump to curr push')
   call add(output, 'q         quit')
   call add(output, '?         toggle this help')
   call add(output, '---------------------------')
@@ -952,6 +954,16 @@ function! s:jump_to_current_branch() abort
   call search(s:icons.current)
 endfunction
 
+function! s:jump_to_current_upstream() abort
+  let upstream = s:get_current_branch_remote_upstream()
+  call search(upstream)
+endfunction
+
+function! s:jump_to_current_push() abort
+  let push = s:get_current_branch_remote_upstream()
+  call search(push)
+endfunction
+
 "     {{{3 bufrefresh
 function! s:bufrefresh()
   if &ft ==# 'gitcommit'
@@ -1140,7 +1152,9 @@ function! s:Render() abort
   nnoremap <buffer> <silent> [[  <cmd>call <SID>traverse_groups('k', 0, v:count1)<CR>
   nnoremap <buffer> <silent> <C-N>  <cmd>call <SID>traverse_groups('j', 0, v:count1)<CR>
   nnoremap <buffer> <silent> <C-P>  <cmd>call <SID>traverse_groups('k', 0, v:count1)<CR>
-  nnoremap <buffer> <silent> J      <cmd>call <SID>jump_to_current_branch()<CR>
+  nnoremap <buffer> <silent> JL      <cmd>call <SID>jump_to_current_branch()<CR>
+  nnoremap <buffer> <silent> JU      <cmd>call <SID>jump_to_current_upstream()<CR>
+  nnoremap <buffer> <silent> JP      <cmd>call <SID>jump_to_current_push()<CR>
   if s:showing_full_ui()
     nnoremap <buffer> <silent> gg    :normal! 4gg<CR>
   else
@@ -1161,8 +1175,7 @@ function! s:Render() abort
   call s:mapping('dd',      'Delete',           [])
   call s:mapping('yy',      'Yank',	            [])
   call s:mapping('F',       'Fetch',            [0]) " deprecated
-  call s:mapping('f',       'Fetch',            [0])
-  call s:mapping('m',       'Merge',            [0, ''])
+  call s:mapping('f',       'Fetch',            [0]) call s:mapping('m',       'Merge',            [0, ''])
   call s:mapping('M',       'Merge',            [1, ''])
   call s:mapping('gm',      'Merge',            [0, '--no-ff'])
   call s:mapping('gM',      'Merge',            [1, '--no-ff'])

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -283,6 +283,8 @@ function! s:parse_branch(branch, type) abort
 
   let branch.hash = pieces[2]
   let branch.msg = pieces[5]
+  let branch.remote_branch = pieces[3]
+  let branch.remote_info = pieces[4][1:-2]
   let branch.remote_details = remote_details
 
   if empty(branch.name) | return {} | endif
@@ -723,8 +725,10 @@ function! s:show_branch_details() abort
 	let name = s:branch_line_refs[line].name 
 	let hash = s:branch_line_refs[line].hash
 	let msg = s:branch_line_refs[line].msg
-	let remote = s:branch_line_refs[line].remote_details
-	let total_len = len(msg) + len(name) + len(hash) + len(remote)
+	let remote_branch = s:branch_line_refs[line].remote_branch
+	let remote_info = s:branch_line_refs[line].remote_info
+	let status = s:branch_line_refs[line].status
+	let total_len = len(msg) + len(name) + len(hash) + len(remote_branch) + len(remote_info)
     if total_len > max_len
 	  let ellipsis = has('multi_byte') ? '…' : '...'
       let msg = msg[0:max_len + len(msg) - total_len - 1 - strcharlen(ellipsis)] . ellipsis
@@ -746,11 +750,23 @@ function! s:show_branch_details() abort
 	  echon hash
 	  echohl clear
 	  echon ')'
-	  if !empty(remote)
+	  if !empty(remote_branch)
 		  echon ' [' 
 		  echohl TwiggyRemote
-		  echon remote 
+		  echon remote_branch
 		  echohl clear
+		  if !empty(remote_info)
+			  echon ': '
+			  if status ==# 'ahead'
+				  echohl TwiggyAhead
+			  elseif status ==# 'behind'
+				  echohl TwiggyBehind
+			  elseif status ==# 'both'
+				  echohl TwiggyAheadBehind
+			  endif
+			  echon remote_info
+			  echohl clear
+		  endif
 		  echon ']'
 	  endif
 	  echon ': '

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1303,7 +1303,6 @@ function! s:Render() abort
 	elseif !a:conceal_local && !empty(a:current)
 		execute('syntax match TwiggyBranchCurrent /\v' .. s:branch_marker_vmagic['local'] .. escape(a:current, '\/\') .. '$/ contains=TwiggyBranchCurrentPrefix,TwiggyBranchCurrentName')
 		execute 'syntax match TwiggyBranchCurrentPrefix /\V' . escape(s:branch_marker['local'], '\/') . '/ contained conceal contains=TwiggyBranchPrefix nextgroup=TwiggyBranchCurrentName'
-		echom a:current
 		execute('syntax match TwiggyBranchCurrentName /\V' .. escape(a:current, '\/\') .. '/ contained')
 	endif
 
@@ -1372,6 +1371,15 @@ function! s:Render() abort
   syntax match TwiggySortText '\v[[a-z]+]'
   highlight default link TwiggySortText Comment
 
+  if s:showing_full_ui()
+    syntax match TwiggyHeader "\v%1l^Twiggy"
+    highlight default link TwiggyHeader Title
+    syntax match TwiggyHelpHint "\v%1lHelp: "
+    highlight default link TwiggyHelpHint fugitiveHelpHeader
+    syntax match TwiggyHelpHintKey "\v%1l\g\?"
+    highlight default link TwiggyHelpHintKey fugitiveHelpTag
+  endif
+
   if exists('s:branches_not_in_reflog') && len(s:branches_not_in_reflog)
     return
     exec "syntax match TwiggyNotInReflog '" .
@@ -1382,15 +1390,6 @@ function! s:Render() abort
 
   exec "syntax match TwiggyDetachedText '\\v%3vHEAD\\@[a-z0-9]+'"
   highlight default link TwiggyDetachedText Identifier
-
-  if s:showing_full_ui()
-    syntax match TwiggyHeader "\v%1lTwiggy"
-    highlight default link TwiggyHeader Title
-    syntax match TwiggyHelpHint "\v%1lHelp: "
-    highlight default link TwiggyHelpHint fugitiveHelpHeader
-    syntax match TwiggyHelpHintKey "\v%1l\g\?"
-    highlight default link TwiggyHelpHintKey fugitiveHelpTag
-  endif
 
   " }}}
 endfunction

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -288,6 +288,7 @@ function! s:parse_branch(branch, type) abort
     let branch.details = join([pieces[2], remote_details, pieces[5]], ' ')
   endif
 
+  if empty(branch.name) | return {} | endif
   return branch
 endfunction
 
@@ -314,7 +315,10 @@ function! s:_git_branch_vv(type) abort
         \ '%(contents:subject)',
         \ ], "\t\t")
   for branch in s:git_cmd('for-each-ref refs/' . a:type . " --format=$'".format."'", 0)
-    call add(branches, s:parse_branch(branch, a:type))
+	let parsed = s:parse_branch(branch, a:type)
+	if !empty(parsed) && !empty(parsed.name)
+		call add(branches, parsed)
+	endif
   endfor
 
   return branches
@@ -530,6 +534,8 @@ function! s:standard_view() abort
 
   let branches = twiggy#get_branches()
   for branch in branches
+	if empty(branch.name) | continue | endif
+
     if !has_key(groups[branch.type], branch.group)
       let groups[branch.type][branch.group] = {}
       if branch.group ==# 'local'

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -746,25 +746,26 @@ function! s:show_branch_details() abort
       unlet t:twiggy_deprecation_notice
     else
 
-	  let icon = trim(decor)
-	  if icon ==# s:icons.current
-		  echohl TwiggyCurrent
-	  elseif icon ==# s:icons.tracking
-		  echohl TwiggyTracking
-	  elseif icon ==# s:icons.ahead
-		  echohl TwiggyAhead
-	  elseif icon ==# s:icons.behind
-		  echohl TwiggyBehind
-	  elseif icon ==# s:icons.both
-		  echohl TwiggyAheadBehind
-	  elseif icon ==# s:icons.detached
-		  echohl TwiggyDetached
-	  elseif icon ==# s:icons.unmerged
-		  echohl TwiggyUnmerged
-	  else
-		  echohl ErrorMsg
-	  endif
-	  echon decor
+	  for icon in decor
+		  if icon ==# s:icons.current
+			  echohl TwiggyCurrent
+		  elseif icon ==# s:icons.tracking
+			  echohl TwiggyTracking
+		  elseif icon ==# s:icons.ahead
+			  echohl TwiggyAhead
+		  elseif icon ==# s:icons.behind
+			  echohl TwiggyBehind
+		  elseif icon ==# s:icons.both
+			  echohl TwiggyAheadBehind
+		  elseif icon ==# s:icons.detached
+			  echohl TwiggyDetached
+		  elseif icon ==# s:icons.unmerged
+			  echohl TwiggyUnmerged
+		  else
+			  echohl ErrorMsg
+		  endif
+		  echon icon
+	  endfor
 	  echohl clear
 
 	  if name =~# '\v^HEAD\@[0-9a-fA-F]+'

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -281,12 +281,9 @@ function! s:parse_branch(branch, type) abort
     let remote_details = remote_details . ': ' . pieces[4][1:-2]
   endif
 
-  if remote_details ==# ''
-    let branch.details = join([pieces[2], pieces[5]], ' ')
-  else
-    let remote_details = '['.remote_details.']'
-    let branch.details = join([pieces[2], remote_details, pieces[5]], ' ')
-  endif
+  let branch.hash = pieces[2]
+  let branch.msg = pieces[5]
+  let branch.remote_details = remote_details
 
   if empty(branch.name) | return {} | endif
   return branch
@@ -723,9 +720,14 @@ function! s:show_branch_details() abort
   let line = line('.')
   if has_key(s:branch_line_refs, line)
     let max_len = &columns - 16
-    let details = s:branch_line_refs[line].details
-    if len(details) > max_len
-      let details = details[0:max_len] . '...'
+	let name = s:branch_line_refs[line].name 
+	let hash = s:branch_line_refs[line].hash
+	let msg = s:branch_line_refs[line].msg
+	let remote = s:branch_line_refs[line].remote_details
+	let total_len = len(msg) + len(name) + len(hash) + len(remote)
+    if total_len > max_len
+	  let ellipsis = has('multi_byte') ? '…' : '...'
+      let msg = msg[0:max_len + len(msg) - total_len - 1 - strcharlen(ellipsis)] . ellipsis
     endif
     redraw
     " Hacky deprecation code
@@ -736,7 +738,24 @@ function! s:show_branch_details() abort
       echohl None
       unlet t:twiggy_deprecation_notice
     else
-      echo details
+	  echohl TwiggyBranchCurrentName
+	  echon name 
+	  echohl clear
+	  echon ' ('
+	  echohl TwiggyGitHash
+	  echon hash
+	  echohl clear
+	  echon ')'
+	  if !empty(remote)
+		  echon ' [' 
+		  echohl TwiggyRemote
+		  echon remote 
+		  echohl clear
+		  echon ']'
+	  endif
+	  echon ': '
+      echon msg
+	  echon
     endif
   end
 endfunction
@@ -1011,6 +1030,8 @@ function! s:Render() abort
     return
   endif
 
+  highlight default link TwiggyGitHash fugitiveHash
+  highlight default link TwiggyRemote fugitiveSymbolicRef
   call s:show_branch_details()
   let s:total_lines = len(output)
 

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1056,7 +1056,7 @@ function! s:Render() abort
   if s:showing_full_ui() && !s:attn_mode()
     " We don't need to manually add a second empty line here since
     " s:standard_view() will automatically add one.
-    call extend(output, ["press ? for help"])
+    call extend(output, ["Twiggy\tHelp: ?"])
   endif
 
   if s:attn_mode()
@@ -1384,10 +1384,12 @@ function! s:Render() abort
   highlight default link TwiggyDetachedText Identifier
 
   if s:showing_full_ui()
-    syntax match TwiggyHelpHint "\v%1l"
-    highlight default link TwiggyHelpHint Normal
+    syntax match TwiggyHeader "\v%1lTwiggy"
+    highlight default link TwiggyHeader Title
+    syntax match TwiggyHelpHint "\v%1lHelp: "
+    highlight default link TwiggyHelpHint Question
     syntax match TwiggyHelpHintKey "\v%1l\?"
-    highlight default link TwiggyHelpHintKey Identifier
+    highlight default link TwiggyHelpHintKey Question
   endif
 
   " }}}
@@ -1428,7 +1430,7 @@ function! s:Quickhelp() abort
   syntax match TwiggyQuickhelpSpecial "\v\`[a-zA-Z]+\`"
   highlight link TwiggyQuickhelpSpecial Identifier
   syntax match TwiggyQuickhelpHeader "\v[A-Za-z ]+\n[=]+"
-  highlight link TwiggyQuickhelpHeader String
+  highlight link TwiggyQuickhelpHeader Title
   syntax match TwiggyQuickhelpSectionHeader "\v[\-]+\n[a-z,\/ \:]+\n[\-]+"
   highlight link TwiggyQuickhelpSectionHeader String
   if g:twiggy_show_full_ui

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1127,7 +1127,16 @@ function! s:Render() abort
 
   " ────────────────────────────────────────────────────────────────────────
   " Conceal slash prefix
+  "
+  " TODO: this still relies on TwiggyCurrent when there is no slash in the
+  " name!
+  "
+  " TODO: this only implements rendering branches for slash sorting, we need to
+  " implement it for non-slash sorting too
   " ────────────────────────────────────────────────────────────────────────
+  let &l:conceallevel = 2
+  let &l:concealcursor = 'nvic'
+
   function! ConcealSlashBranches(current, current_remote, conceal_local, conceal_remote)
     syntax clear TwiggySlash
     syntax clear TwiggySlashPrefix
@@ -1144,10 +1153,13 @@ function! s:Render() abort
 		let slash_prefix = '(r)'
 	endif
 
-	execute('syntax region TwiggySlash start=/\v' . escape(slash_prefix, '()') . '[-_[:alnum:].]+\// end=/\v[()-_[:alnum:].\/]+/ contains=TwiggySlashPrefix,TwiggySlashBranchPrefix,TwiggySlashBranchName oneline')
+	execute('syntax region TwiggySlash start=/\v' . escape(slash_prefix, '()') . '[-_[:alnum:].]+\// end=/\v[()-_[:alnum:].\/]+/ contains=TwiggySlashBranchPrefix,TwiggySlashBranchName oneline')
 
+	" local
+	syntax match TwiggySlashBranchPrefix /\v\(l\)[-_[:alnum:].]+\// contained conceal nextgroup=TwiggySlashBranchName contains=TwiggySlashPrefix
+	" remote
+	syntax match TwiggySlashBranchPrefix /\v\(r\)[-_[:alnum:].]+\/[-_[:alnum:].]+\// contained conceal nextgroup=TwiggySlashBranchName contains=TwiggySlashPrefix
 	syntax match TwiggySlashBranchName   /\v[-_[:alnum:].\/]+/ contained
-	syntax match TwiggySlashBranchPrefix /\v[-_[:alnum:].]+\// contained conceal
   
 	if a:conceal_local && !empty(a:current)
 		let parts = split(a:current, '/')
@@ -1156,8 +1168,8 @@ function! s:Render() abort
 		let prefix = parts[0] .. '/'
 		let name = join(parts[1 :], '/')
 
-		execute('syntax match TwiggySlashCurrent /\v' .. escape(slash_prefix, '()') .. escape(a:current, '\/\') .. '/ contains=TwiggySlashPrefix,TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
-		execute('syntax match TwiggySlashCurrentPrefix /\V' .. escape(prefix, '\/\') .. '/ contained conceal nextgroup=TwiggySlashCurrentName')
+		execute('syntax match TwiggySlashCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
+		execute('syntax match TwiggySlashCurrentPrefix /\V(l)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName')
 		execute('syntax match TwiggySlashCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
 	endif
 
@@ -1168,16 +1180,15 @@ function! s:Render() abort
 		let prefix = join(parts[0 : 1], '/') .. '/'
 		let name = join(parts[2 :], '/')
 
-		execute('syntax match TwiggySlashCurrent /\v' .. escape(slash_prefix, '()') .. escape(a:current_remote, '\/\') .. '/ contains=TwiggySlashPrefix,TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
-		execute('syntax match TwiggySlashCurrentPrefix /\V' .. escape(prefix, '\/\') .. '/ contained conceal nextgroup=TwiggySlashCurrentName')
+		" TODO: name clashing with local conceals above!
+		execute('syntax match TwiggySlashCurrent /\v\(r\)' .. escape(a:current_remote, '\/\') .. '/ contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
+		execute('syntax match TwiggySlashCurrentPrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName')
 		execute('syntax match TwiggySlashCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
 	endif
 
 	echom 'syntax match TwiggySlashPrefix /\v' . escape(slash_prefix, '()') . '/ contained conceal'
 	execute('syntax match TwiggySlashPrefix /\v' . escape(slash_prefix, '()') . '/ contained conceal')
   
-    let &l:conceallevel = 2
-    let &l:concealcursor = 'nvic'
   endfunction
 
   " TODO: this will highlight remote branches of the same name, even if they

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -769,8 +769,7 @@ function! s:show_branch_details() abort
 		  endif
 		  echon ']'
 	  endif
-	  echon ': '
-      echon msg
+      echon ' ' . msg
 	  echon
     endif
   end

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -728,7 +728,7 @@ function! s:show_branch_details() abort
 	let remote_branch = s:branch_line_refs[line].remote_branch
 	let remote_info = s:branch_line_refs[line].remote_info
 	let status = s:branch_line_refs[line].status
-	let total_len = len(msg) + len(name) + len(hash) + len(remote_branch) + len(remote_info)
+	let total_len = 8 + len(msg) + len(name) + len(hash) + len(remote_branch) + len(remote_info)
     if total_len > max_len
 	  let ellipsis = has('multi_byte') ? '…' : '...'
       let msg = msg[0:max_len + len(msg) - total_len - 1 - strcharlen(ellipsis)] . ellipsis

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1174,7 +1174,7 @@ function! s:Render() abort
 
 	" remote: match either (r)remote/prefix/name or (r)
 	syntax match TwiggySlashRemoteBranchPrefix /\v\(r\)/ contained conceal nextgroup=TwiggySlashRemoteBranchName contains=TwiggySlashPrefix
-	syntax match TwiggySlashRemoteBranchPrefix /\v\(r\)[-_[:alnum:].]+\/[-_[:alnum:].]+\// contained conceal nextgroup=TwiggySlashRemoteBranchName contains=TwiggySlashPrefix
+	syntax match TwiggySlashRemoteBranchPrefix /\v\(r\)([-_[:alnum:].]+\/){1,2}/ contained conceal nextgroup=TwiggySlashRemoteBranchName contains=TwiggySlashPrefix
 	syntax match TwiggySlashRemoteBranchName   /\v[-_[:alnum:].\/]+/ contained
  
 	if a:conceal_local && !empty(a:current)
@@ -1184,8 +1184,6 @@ function! s:Render() abort
 			syntax match TwiggySlashCurrentPrefix /\V(l)/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName
 			execute('syntax match TwiggySlashCurrentName /\V' .. a:current .. '/ contained')
 		else
-			execute('syntax match TwiggySlashCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
-
 			let prefix = parts[0] .. '/'
 			let name = join(parts[1 :], '/')
 
@@ -1193,6 +1191,10 @@ function! s:Render() abort
 			execute('syntax match TwiggySlashCurrentPrefix /\V(l)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName')
 			execute('syntax match TwiggySlashCurrentName /\V' .. escape(name, '\/\') .. '/ contained')
 		endif
+	elseif !a:conceal_local && !empty(a:current)
+		execute('syntax match TwiggySlashCurrent /\v\(l\)' .. escape(a:current, '\/\') .. '/ contains=TwiggySlashCurrentPrefix,TwiggySlashCurrentName')
+		syntax match TwiggySlashCurrentPrefix /\V(l)/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentName
+		execute('syntax match TwiggySlashCurrentName /\V' .. escape(a:current, '\/\') .. '/ contained')
 	endif
 
 	if a:conceal_remote && !empty(a:current_remote)
@@ -1208,6 +1210,14 @@ function! s:Render() abort
 		execute('syntax match TwiggySlashCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '/ contains=TwiggySlashCurrentRemotePrefix,TwiggySlashCurrentRemoteName')
 		execute('syntax match TwiggySlashCurrentRemotePrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentRemoteName')
 		execute('syntax match TwiggySlashCurrentRemoteName /\V' .. escape(name, '\/\') .. '/ contained')
+	elseif !a:conceal_remote && !empty(a:current_remote)
+		let parts = split(a:current_remote, '/')
+		let prefix = parts[0] .. '/'
+		let name = join(parts[1 :], '/')
+
+		execute('syntax match TwiggySlashCurrentRemote /\v\(r\)' .. escape(a:current_remote, '\/\') .. '/ contains=TwiggySlashCurrentRemotePrefix,TwiggySlashCurrentRemoteName')
+		execute('syntax match TwiggySlashCurrentRemotePrefix /\V(r)' .. escape(prefix, '\/\') .. '/ contained conceal contains=TwiggySlashPrefix nextgroup=TwiggySlashCurrentRemoteName')
+		execute('syntax match TwiggySlashCurrentRemoteName /\V' .. escape(name, '\/\') .. '/ contained')
 	endif
 
 	" execute('syntax match TwiggySlashPrefix /\v' . escape(slash_prefix, '()') . '/ contained conceal')
@@ -1216,17 +1226,9 @@ function! s:Render() abort
   
   endfunction
 
-  " TODO: this will highlight remote branches of the same name, even if they
-  " are not tracked by the current branch!
   let current_branch = s:get_current_branch()
   let current_branch_remote = s:get_current_branch_remote()
-
-  if g:twiggy_group_locals_by_slash || g:twiggy_group_remotes_by_slash
-	  call ConcealSlashBranches(current_branch, current_branch_remote, g:twiggy_group_locals_by_slash, g:twiggy_group_remotes_by_slash)
-  else
-	  exec "syntax match TwiggyCurrent '\\v%3v" . current_branch . "$'"
-	  highlight default link TwiggyCurrent Identifier
-  endif
+  call ConcealSlashBranches(current_branch, current_branch_remote, g:twiggy_group_locals_by_slash, g:twiggy_group_remotes_by_slash)
 
   exec "syntax match TwiggyCurrent '\\V\\%1c" . s:icons.current . "'"
   highlight default link TwiggyCurrent Identifier

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -725,11 +725,11 @@ function! s:show_branch_details() abort
   if has_key(s:branch_line_refs, line)
     let max_len = &columns - 16
 	let name = s:branch_line_refs[line].name 
-	let hash = s:branch_line_refs[line].hash
-	let msg = s:branch_line_refs[line].msg
-	let remote_branch = s:branch_line_refs[line].remote_branch
-	let remote_info = s:branch_line_refs[line].remote_info
-	let status = s:branch_line_refs[line].status
+	let hash = get(s:branch_line_refs[line], "hash", "")
+	let msg = get(s:branch_line_refs[line], "msg", "")
+	let remote_branch = get(s:branch_line_refs[line], "remote_branch", "")
+	let remote_info = get(s:branch_line_refs[line], "remote_info", "")
+	let status = get(s:branch_line_refs[line], "status", "")
 	let total_len = 8 + len(msg) + len(name) + len(hash) + len(remote_branch) + len(remote_info)
     if total_len > max_len
 	  let ellipsis = has('multi_byte') ? '…' : '...'
@@ -747,11 +747,13 @@ function! s:show_branch_details() abort
 	  echohl TwiggyBranchCurrentName
 	  echon name 
 	  echohl clear
-	  echon ' ('
-	  echohl TwiggyCommitHash
-	  echon hash
-	  echohl clear
-	  echon ')'
+	  if !empty(hash)
+		  echon ' ('
+		  echohl TwiggyCommitHash
+		  echon hash
+		  echohl clear
+		  echon ')'
+	  endif
 	  if !empty(remote_branch)
 		  echon ' [' 
 		  echohl TwiggyRemote
@@ -771,10 +773,12 @@ function! s:show_branch_details() abort
 		  endif
 		  echon ']'
 	  endif
-	  echohl TwiggyCommitMessage
-      echon ' ' . msg
-	  echohl clear
-	  echon
+	  if !empty(msg)
+		  echohl TwiggyCommitMessage
+		  echon ' ' . msg
+		  echohl clear
+		  echon
+	  endif
     endif
   end
 endfunction

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -638,7 +638,7 @@ function! s:quickhelp_view() abort
   call add(output, 'JU        jump to curr upstream')
   call add(output, 'JP        jump to curr push')
   call add(output, 'q         quit')
-  call add(output, '?         toggle this help')
+  call add(output, 'g?        toggle this help')
   call add(output, '---------------------------')
   call add(output, 'w/ the cursor on a branch:')
   call add(output, '---------------------------')
@@ -1029,7 +1029,7 @@ function! s:Render() abort
 
   nnoremap <buffer> <silent> q :<C-U>call <SID>Close()<CR>
   if g:twiggy_enable_quickhelp
-    nnoremap <buffer> <silent> ? :<C-U>call <SID>Quickhelp()<CR>
+    nnoremap <buffer> <silent> g? :<C-U>call <SID>Quickhelp()<CR>
   endif
 
   autocmd! BufWinLeave twiggy://*
@@ -1056,7 +1056,7 @@ function! s:Render() abort
   if s:showing_full_ui() && !s:attn_mode()
     " We don't need to manually add a second empty line here since
     " s:standard_view() will automatically add one.
-    call extend(output, ["Twiggy\tHelp: ?"])
+    call extend(output, ["Twiggy\tHelp: g?"])
   endif
 
   if s:attn_mode()
@@ -1388,7 +1388,7 @@ function! s:Render() abort
     highlight default link TwiggyHeader Title
     syntax match TwiggyHelpHint "\v%1lHelp: "
     highlight default link TwiggyHelpHint fugitiveHelpHeader
-    syntax match TwiggyHelpHintKey "\v%1l\?"
+    syntax match TwiggyHelpHintKey "\v%1l\g\?"
     highlight default link TwiggyHelpHintKey fugitiveHelpTag
   endif
 
@@ -1416,7 +1416,7 @@ function! s:Quickhelp() abort
   let bufnr = bufnr('')
 
   nnoremap <buffer> <silent> q :quit<CR>
-  nnoremap <buffer> <silent> ? :Twiggy<CR>
+  nnoremap <buffer> <silent> g? :Twiggy<CR>
 
   call append(0, s:quickhelp_view())
   normal! G


### PR DESCRIPTION
This PR improves branch highlighting with and without slash sorting.

Before, the current branch was not highlighted with slash sorting (only the `*` indicator was). This PR fixes that, highlighting the entire current branch text regardless of slash sorting.

Before, Twiggy made the assumption that remote tracking branches always had the same branch name as their local branch counterparts. This assumption (though commonly satisfied) is incorrect. This PR addresses this by asking `git` what the remote tracking branch is for the currently active branch and highlighting that remote tracking branch (rather than using a name-matching strategy).