### PR TITLE
feat: update `:Twiggy` command interface

### DIFF
--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1588,17 +1588,10 @@ endfunction
 
 "   {{{2 Git
 "     {{{3 Checkout
-function! s:Checkout(track, merge) abort
-  let current_branch = s:get_current_branch()
-  let switch_branch = s:branch_under_cursor()
-  let merge_opt = a:merge ? ' --merge ' : ''
-
-  if s:dirty_tree() && !a:merge
+function! s:ShowDirtyTreeOnCheckoutMessage()
     let dirty_files = s:git_cmd('diff --name-only', 0)
     let warning = 'error: Your local changes to the following files would be overwritten by checkout:'
-    let s:last_output = [
-          \ warning
-          \ ]
+    let s:last_output = [warning]
     call extend(s:last_output, map(dirty_files, '"\t" . v:val'))
     call extend(s:last_output, [
           \ 'Please commit your changes or stash them before you switch branches.',
@@ -1606,6 +1599,15 @@ function! s:Checkout(track, merge) abort
           \ ])
     let v:warningmsg = warning
     call s:RenderOutputBuffer()
+endfunction
+
+function! s:Checkout(track, merge) abort
+  let current_branch = s:get_current_branch()
+  let switch_branch = s:branch_under_cursor()
+  let merge_opt = a:merge ? ' --merge ' : ''
+
+  if s:dirty_tree() && !a:merge
+	call s:ShowDirtyTreeOnCheckoutMessage()
     return 1
   endif
 

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -62,6 +62,8 @@ let s:requires_buf_refresh     = 1
 let s:sorted      = 0
 let s:git_cmd_run = 0
 
+let s:worktree_branches = {}
+
 let s:branch_marker = {
       \ 'local': '(l)',
       \ 'remote': '(r)'
@@ -74,12 +76,12 @@ let s:branch_marker_vmagic = {
 " {{{1 Icons
 if exists('g:twiggy_icons')
       \ && type(g:twiggy_icons) == 3
-      \ && len(filter(g:twiggy_icons, 'type(v:val) ==# 1 && strchars(v:val) ==# 1')) ==# 7
+      \ && len(filter(g:twiggy_icons, 'type(v:val) ==# 1 && strchars(v:val) ==# 1')) ==# 8
   let s:icon_set = g:twiggy_icons
 elseif has('multi_byte')
-  let s:icon_set = ['*', '✓', '↑', '↓', '↕', '∅', '✗']
+  let s:icon_set = ['*', '✓', '↑', '↓', '↕', '∅', '✗', '+']
 else
-  let s:icon_set = ['*', '=', '+', '-', '~', '%', 'x']
+  let s:icon_set = ['*', '=', '+', '-', '~', '%', 'x', '+']
 endif
 
 let s:ellipsis = has('multi_byte') ? '…' : '...'
@@ -91,6 +93,7 @@ let s:icons.behind   = s:icon_set[3]
 let s:icons.both     = s:icon_set[4]
 let s:icons.detached = s:icon_set[5]
 let s:icons.unmerged = s:icon_set[6]
+let s:icons.worktree = s:icon_set[7]
 
 
 " {{{1 Options
@@ -225,6 +228,8 @@ function! s:parse_branch(branch, type) abort
   if branch.current
     let git_mode = exists('t:twiggy_git_mode') ? t:twiggy_git_mode : s:get_git_mode()
     let branch.decoration = git_mode !=# 'normal' ? s:icons.unmerged : s:icons.current
+  elseif has_key(s:worktree_branches, pieces[1])
+    let branch.decoration = s:icons.worktree
   endif
 
   let remote_details = pieces[3] . ' ' . pieces[4]
@@ -353,8 +358,23 @@ function! s:get_git_mode() abort
   endif
 endfunction
 
+"   {{{2 update_worktree_branches
+function! s:update_worktree_branches() abort
+  let s:worktree_branches = {}
+  let worktree_count = 0
+  for line in s:git_cmd('worktree list --porcelain', 0)
+    if line =~# '^worktree '
+      let worktree_count += 1
+    elseif line =~# '^branch ' && worktree_count > 1
+      let branchname = substitute(matchstr(line, '^branch \zs.*'), '^refs/heads/', '', '')
+      let s:worktree_branches[branchname] = 1
+    endif
+  endfor
+endfunction
+
 "   {{{2 get_branches
 function! twiggy#get_branches() abort
+  call s:update_worktree_branches()
   let locals = s:_git_branch_vv('heads')
   let locals_sorted = []
 
@@ -784,6 +804,8 @@ function! s:show_branch_details() abort
 			  echohl TwiggyDetached
 		  elseif icon ==# s:icons.unmerged
 			  echohl TwiggyUnmerged
+		  elseif icon ==# s:icons.worktree
+			  echohl TwiggyWorktree
 		  else
 			  echohl ErrorMsg
 		  endif
@@ -1363,6 +1385,9 @@ function! s:Render() abort
 
   exec "syntax match TwiggyUnmerged '\\V\\%1c" . s:icons.unmerged . "'"
   highlight default link TwiggyUnmerged Identifier
+
+  exec "syntax match TwiggyWorktree '\\V\\%1c" . s:icons.worktree . "'"
+  highlight default link TwiggyWorktree Special
 
   syntax match TwiggySortText '\v[[a-z]+]'
   highlight default link TwiggySortText Comment

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1378,17 +1378,17 @@ function! s:Render() abort
   exec "syntax match TwiggyCurrent '\\V\\%1c" . s:icons.current . "'"
   highlight default link TwiggyCurrent Identifier
 
-  exec "syntax match TwiggyTracking '\\V\\%2c" . s:icons.tracking . "'"
+  exec "syntax match TwiggyTracking '\\V\\%2v" . s:icons.tracking . "'"
   highlight default link TwiggyTracking String
 
-  exec "syntax match TwiggyAhead '\\V\\%2c" . s:icons.ahead . "'"
+  exec "syntax match TwiggyAhead '\\V\\%2v" . s:icons.ahead . "'"
   highlight default link TwiggyAhead Type
 
-  exec "syntax match TwiggyAheadBehind '\\V\\%2c" . s:icons.behind . "'"
-  exec "syntax match TwiggyAheadBehind '\\V\\%2c" . s:icons.both . "'"
+  exec "syntax match TwiggyAheadBehind '\\V\\%2v" . s:icons.behind . "'"
+  exec "syntax match TwiggyAheadBehind '\\V\\%2v" . s:icons.both . "'"
   highlight default link TwiggyAheadBehind Type
 
-  exec "syntax match TwiggyDetached '\\V\\%2c" . s:icons.detached . "'"
+  exec "syntax match TwiggyDetached '\\V\\%2v" . s:icons.detached . "'"
   highlight default link TwiggyDetached ErrorMsg
 
   exec "syntax match TwiggyUnmerged '\\V\\%1c" . s:icons.unmerged . "'"

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -79,7 +79,7 @@ if exists('g:twiggy_icons')
       \ && len(filter(g:twiggy_icons, 'type(v:val) ==# 1 && strchars(v:val) ==# 1')) ==# 8
   let s:icon_set = g:twiggy_icons
 elseif has('multi_byte')
-  let s:icon_set = ['*', '✓', '↑', '↓', '↕', '∅', '✗', '+']
+  let s:icon_set = ['*', '✓', '↑', '↓', '↕', '∅', '✗', '⊞']
 else
   let s:icon_set = ['*', '=', '+', '-', '~', '%', 'x', '+']
 endif

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -865,6 +865,7 @@ function! s:RenderOutputBuffer() abort
     return
   endif
   silent keepalt botright new TwiggyOutput
+  setlocal filetype=twiggyoutput
   let output = s:last_output
   let height = len(output)
   if height < 5 | let height = 5 | endif

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1,8 +1,7 @@
 " twiggy.vim -- Maintain your bearings while branching with git
-" Maintainer: Andrew Haust <andrewwhhaust@gmail.com>
-" Website:    https://www.github.com/sodapopcan/vim-twiggy
+" Maintainer: Samuel Neumann <samuelfneumann@gmail.com>
+" Website:    https://samuelfneumann.github.io/
 " License:    Same terms as Vim itself (see :help license)
-" Version:    0.4
 
 if exists('g:autoloaded_twiggy')
   finish

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -889,6 +889,14 @@ function! s:RenderOutputBuffer() abort
   highlight link TwiggyOutputFile File
 endfunction
 
+function! twiggy#CloseOutputBuffer() abort
+	for info in getbufinfo()
+	  if getbufvar(info.bufnr, '&filetype') ==# 'twiggyoutput'
+		execute 'bwipeout' info.bufnr
+	  endif
+	endfor
+endfunction
+
 "   {{{2 Confirm
 function! s:Confirm(prompt, cmd, abort) abort
   redraw
@@ -1508,12 +1516,31 @@ function! s:Refresh() abort
   unlet t:refreshing
 endfunction
 
+"     {{{3 Main
+function! twiggy#Main(...) abort
+  if len(a:000) == 0
+    call twiggy#Branch()
+  elseif a:000[0] ==# 'switch'
+    if len(a:000) < 2
+      echo "Usage: :Twiggy switch BRANCH"
+      return
+    endif
+    call call('twiggy#Branch', a:000[1:])
+  elseif a:000[0] ==# 'close'
+    call twiggy#CloseOutputBuffer()
+  else
+	echohl ErrorMsg
+    echo "Unknown Twiggy subcommand: " . a:000[0]
+	echohl clear
+  endif
+endfunction
+
 "     {{{3 Branch
 function! twiggy#Branch(...) abort
   if len(a:000)
     let current_branch = s:get_current_branch()
-    let f = s:branch_exists(a:1) ? '' : '-b '
-    call s:git_cmd('checkout ' . f . join(a:000), 0)
+    let f = s:branch_exists(a:1) ? '' : '-c '
+    call s:git_cmd('switch ' . f . join(a:000), 0)
     call s:RenderOutputBuffer()
     if exists('t:twiggy_bufnr')
       call s:Refresh()
@@ -1719,7 +1746,7 @@ function! s:DeleteRemote() abort
 
   return s:Confirm(
         \ 'WARNING! Delete branch ' . branch.name . ' from remote repo: ' . branch.group . '?',
-        \ "s:git_cmd('push " . branch.group . " :" . branch.name . "', 1)[0]", 0)
+        \ "s:git_cmd('push --delete " . branch.group . " :" . branch.name . "', 1)[0]", 0)
 endfunction
 
 "     {{{3 Fetch

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -1630,6 +1630,11 @@ function! s:Checkout(track, merge) abort
     else " tracking and branch is local
       call s:git_cmd('switch ' . merge_opt . switch_branch.fullname, 0)
     endif
+
+    if v:shell_error
+      call s:RenderOutputBuffer()
+      return 1
+    endif
   endif
 
   let s:init_line = 0

--- a/autoload/twiggy.vim
+++ b/autoload/twiggy.vim
@@ -885,7 +885,7 @@ function! s:RenderOutputBuffer() abort
   syntax match TwiggyOutputText "\v^[^ ](.*)"
   highlight link TwiggyOutputText  Comment
   syntax match TwiggyOutputFile "\v^\t(.*)"
-  highlight link TwiggyOutputFile Constant
+  highlight link TwiggyOutputFile File
 endfunction
 
 "   {{{2 Confirm

--- a/doc/twiggy.txt
+++ b/doc/twiggy.txt
@@ -9,17 +9,21 @@ Maintain your bearings while working with git branches.
 
 COMMANDS                                        *twiggy-commands*
 
-:Twiggy [args]              With no arguments, open a split containing an
-                            interactive and decorated list of branches. See
-                            |twiggy-mappings| for a list of available
-                            buffer-local mappings.
+:Twiggy [{sub-command}] [{args}]
+    With no arguments, open a split containing an interactive and decorated
+    list of branches. See |twiggy-mappings| for a list of available
+    buffer-local mappings.
 
-                            If [branch] is given, it will be checked-out -- If
-                            the branch does not exist, it will be created
-                            first.  In this regard, it acts like a cross between
-                            the `git branch` and `git checkout` commands.  You
-                            may also provide the starting point branch as a
-                            second argument.
+    [sub-command] is a Twiggy sub-command, one of:
+    
+    'switch' {branch}  
+        If [branch] is given, it will be checked-out -- If the branch does not
+        exist, it will be created first.  In this regard, it acts like a cross
+        between the `git branch` and `git checkout` commands.  You may also
+        provide the starting point branch as a second argument.
+
+    'close'
+        Closes all opened 'TwiggyOutput' buffers
 
 
 FUGITIVE COMPATIBILITY                         *twiggy-fugitive*
@@ -46,12 +50,13 @@ multi_byte    standard
 ↕             ~             branch is both ahead and behind its upstream
 ∅             %             branch is detached
 ✗             x             in merge/rebase/stash conflict state
+⊞             +             branch is checked out in a worktree
 
 You may also use you own icons by setting the following in your vimrc:
 >
-  let g:twiggy_icons = ['*', '=', '+', '-', '~', '%', 'x']
+  let g:twiggy_icons = ['*', '=', '+', '-', '~', '%', 'x', '+']
 <
-The list must have 7, single character entries.  The first position is used
+The list must have 8, single character entries.  The first position is used
 for the current branch then the rest are in the order listed in the above
 legend.
 
@@ -188,7 +193,7 @@ Prompts to make sure you really want to force push (with lease).  Turn this off 
 <
                                                 *'enable_quickhelp'*
 Default: 1
-Enables |twiggy-?| for quickhelp.  To turn it off:
+Enables |twiggy-g?| for quickhelp.  To turn it off:
 >
   let g:twiggy_enable_quickhelp = 0
 <
@@ -209,8 +214,14 @@ MAPPINGS                                        *twiggy-mappings*
                                                 *twiggy-<C-P>*
 <C-P>             Jump to the first branch of the previous group
 
-                                                *twiggy-<C-^>*
-J                 Jump to the current branch
+                                                *twiggy-JL*
+JL                Jump to the current branch
+
+                                                *twiggy-JU*
+JU                Jump to the current branch's upstream
+
+                                                *twiggy-JP*
+JP                Jump to the current branch's push destination
 
                   Sorting~
                                                 *twiggy-i*
@@ -243,6 +254,9 @@ c                 Checkout the branch under the cursor.  If the branch is a
                   remote, create a tracking branch if one doesn't already
                   exist, otherwise, checkout in detached HEAD.
 
+                                                *twiggy-cm*
+cm               Same as c but with `--merge`
+
                                                 *twiggy-C*
 C                 Checkout the remote branch under the cursor in detached
                   HEAD.  If the branch is a local tracking branch, it will
@@ -256,6 +270,9 @@ C                 Checkout the remote branch under the cursor in detached
 
                                                 *twiggy-o*
 o                 Same as c
+
+                                                *twiggy-om*
+o                 Same as o but with `--merge`
 
                                                 *twiggy-O*
 O                 Same as C
@@ -273,7 +290,7 @@ cb<space>         Populate command line with "G branch "
 co<space>         Populate command line with "G checkout "
 
                                                 *twiggy-s<space>*
-s<space>         Populate command line with "G switch "
+cs<space>         Populate command line with "G switch "
 
                   Committing~
                                                 *twiggy-c<space>*
@@ -415,8 +432,8 @@ q                 Quit
                                                 *twiggy-Q*
 Q                 Quit all twiggy buffers (including the error buffer)
 
-                                                *twiggy-?*
-?                 Open the quickhelp
+                                                *twiggy-g?*
+g?                Open the quickhelp
 
 
 AUTOCOMMANDS                                    *twiggy-autocommands*
@@ -446,5 +463,6 @@ TwiggyIconAhead             Type         icon: branch is ahead of remote
 TwiggyIconAheadBehind       Type         icon: branch is both ahead and behind
 TwiggyIconDetached          Identifier   icon: current branch is detached
 TwiggyIconUnmerged          Type         icon: current branch is unmerged
+TwiggyWorktree              Special      icon: branch is checked out in a worktree
 
   vim:tw=78:et:ft=help:norl:

--- a/plugin/twiggy.vim
+++ b/plugin/twiggy.vim
@@ -1,6 +1,6 @@
 " twiggy.vim -- Maintain your bearings while branching with git
-" Maintainer: Andrew Haust <andrewwhhaust@gmail.com>
-" Website:    https://www.github.com/sodapopcan/vim-twiggy
+" Maintainer: Samuel Neumann <samuelfneumann@gmail.com>
+" Website:    https://samuelfneumann.github.io/
 " License:    Same terms as Vim itself (see :help license)
 
 if exists('g:loaded_twiggy') || &cp

--- a/plugin/twiggy.vim
+++ b/plugin/twiggy.vim
@@ -8,6 +8,25 @@ if exists('g:loaded_twiggy') || &cp
 endif
 let g:loaded_twiggy = 1
 
+function! TwiggyComplete(A,L,P) abort
+  let parts = split(a:L)
+  let subcommands = ['switch', 'close']
+
+  if len(parts) <= 2 && (len(parts) < 2 || index(subcommands, parts[1]) < 0)
+    let completions = ''
+    for cmd in subcommands
+      if match(cmd, '^' . a:A) >= 0
+        let completions = completions . cmd . "\n"
+      endif
+    endfor
+    return completions
+  elseif len(parts) > 1 && parts[1] ==# 'switch'
+    return TwiggyCompleteBranches(a:A, a:L, a:P)
+  endif
+
+  return ''
+endfunction
+
 function! TwiggyCompleteBranches(A,L,P) abort
   let branches = ''
   for branch in twiggy#get_branches()
@@ -18,4 +37,6 @@ function! TwiggyCompleteBranches(A,L,P) abort
   return branches
 endfunction
 
-command -nargs=* -complete=custom,TwiggyCompleteBranches Twiggy call twiggy#Branch(<f-args>)
+command -nargs=* -complete=custom,TwiggyComplete Twiggy call twiggy#Main(<f-args>)
+command -nargs=* -complete=custom,TwiggyComplete T call twiggy#Main(<f-args>)
+command CloseTwiggyOutput call twiggy#CloseOutputBuffer()


### PR DESCRIPTION
This PR updates the `:Twiggy` command. It now accepts sub-commands like `:Twiggy SUBCOMMAND ARGS`. The current `:Twiggy` functionality is subsumed by `:Twiggy switch`, with `:Twiggy` opening the Twiggy buffer. A new sub-command `:Twiggy close` closes all `TwiggyOutput` buffers.

## Additional Things
- Adds a worktree icon indicator
- Updates `TwiggyOutputFile` to link to `File` rather than `Constant`
- Shows more git errors when a checkout/switch fails